### PR TITLE
Docker database setup

### DIFF
--- a/database/config/init.sql
+++ b/database/config/init.sql
@@ -1,0 +1,7 @@
+-- init file for postgres database
+-- this is run at startup (on new build)
+-- any changes to this file will be take effect after running the following commands (or windows equivalent):
+-- docker container stop postgres
+-- docker-compose down -v
+-- sudo rm -rf database/
+-- docker-compose up -d --build

--- a/database/docker-compose.yaml
+++ b/database/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: "3"
+
+services:
+  postgres:
+    image: "postgres:latest"
+    container_name: "postgres"
+    environment: 
+      POSTGRES_DB: "honeypot_db"
+      POSTGRES_USER: "user"
+      POSTGRES_PASSWORD: "password"
+    ports:
+      - "5432:5432"
+    volumes:
+      - "./database:/var/lib/postgresql/data"
+      - "./config:/docker-entrypoint-initdb.d"


### PR DESCRIPTION
Docker containing a postgres SQL database. Listening to port 5432, saves database to ./database/. Loads .sql files from ./config/ first time it is build, this can be used to create tables, views etc. \n Log in using psql -p 5432 -d honeypot_db -U <username> -h <ip>