### PR TITLE
Frontend attack logging interface (into ssh_conn_info)

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -2,7 +2,7 @@
 name: User Story
 about: A template for user stories in Github issues
 title: ''
-labels: user story
+labels: ''
 assignees: ''
 
 ---

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,7 @@ coverage = {extras = ["toml"], version = "^5.4"}
 
 # Pytest
 [tool.pytest.ini_options]
-addopts = "--html=tests_output/report.html --self-contained-html --cov --cov-report=term --cov-report=html"
+addopts = "--doctest-modules --html=tests_output/report.html --self-contained-html --cov --cov-report=term --cov-report=html"
 cache_dir = "tests_output/.pytest_cache"
 
 # Testing coverage

--- a/frontend/frontend/__main__.py
+++ b/frontend/frontend/__main__.py
@@ -3,6 +3,7 @@ import paramiko
 
 import frontend.protocols.ssh as ssh
 
-key = paramiko.RSAKey(filename="./host.key")
-s = ssh.ConnectionManager(host_key=key, port=2222)
-s.listen()
+if __name__ == '__main__':
+    key = paramiko.RSAKey(filename="./host.key")
+    s = ssh.ConnectionManager(host_key=key, port=2222)
+    s.listen()

--- a/frontend/frontend/logging/__init__.py
+++ b/frontend/frontend/logging/__init__.py
@@ -1,0 +1,88 @@
+"""Module for logging attacker sessions and actions.
+
+Example Usage (SSH):
+>>> with begin_ssh_session(src_address=ip_address('43.56.223.156'),
+...                        src_port=3463,
+...                        dst_address=ip_address('226.64.12.2'),
+...                        dst_port=22,
+...                        term='xterm') as session:
+...     session.log_login_attempt('a_username', 'some_password')
+...     session.log_command('sudo rm -rf /')
+"""
+
+from typing import Iterator, Optional, Protocol
+from abc import abstractmethod
+from contextlib import contextmanager
+from ipaddress import ip_address
+from ._types import IPAddress
+from . import _console
+
+
+class Session(Protocol):
+    """Representation of an attacker's session while being connected to the honeypot."""
+
+    @abstractmethod
+    def log_login_attempt(self, username: str, password: str) -> None:
+        """Logs a new login attempt associated with the current session.
+
+        :param username: The username used in the login attempt.
+        :param password: The password used in the login attempt.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_command(self, input: str) -> None:
+        """Logs a new command associated with the current session.
+
+        :param input: The raw string that was input to run the command.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_download(self,
+                     data: memoryview,
+                     file_type: str,
+                     source_address: IPAddress,
+                     source_url: Optional[str] = None,
+                     save_data: bool = True) -> None:
+        """Logs a new downloaded file associated with the current session.
+
+        :param data: The binary contents of the downloaded file.
+        :param file_type: The file type of the downloaded file. Should be a valid MIME type.
+            If unknown, `application/octet-stream` should be used.
+        :param source_address: The IP address of the downloaded file's source.
+        :param source_url: If known, the URL where the downloaded file originated from.
+        :param save_data: If true, the binary contents of the downloaded file will be saved,
+            if not, only metadata is saved.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def end(self) -> None:
+        """Marks the session as having ended."""
+        raise NotImplementedError
+
+
+@contextmanager
+def begin_ssh_session(src_address: IPAddress, src_port: int,
+                      dst_address: IPAddress, dst_port: int,
+                      term: str) -> Iterator[Session]:
+    """Begins to log a new SSH session.
+
+    :param src_address: The IP address of the instigating origin of the session.
+    :param src_port: The port number at the instigating origin.
+    :param dst_address: The public IP address of the honeypot.
+    :param dst_port: The port at the honeypot.
+    :param term: The SSH ``TERM`` environment variable.
+    :yield: An established SSH session.
+    """
+
+    session = _console.SSHSession(src_address=src_address,
+                                  src_port=src_port,
+                                  dst_address=dst_address,
+                                  dst_port=dst_port,
+                                  term=term)
+    try:
+        yield session
+    finally:
+        session.end()

--- a/frontend/frontend/logging/_console.py
+++ b/frontend/frontend/logging/_console.py
@@ -7,21 +7,27 @@ from ._types import IPAddress
 logger = logging.getLogger(__name__)
 
 
-class SSHSession:
-    """Implementation of logging.Session that merely logs actions to console"""
+class ConsoleLogSSHSession:
+    """Implementation of logging.SSHSession that merely logs actions to console"""
 
     source: str
 
     def __init__(self,
                  src_address: IPAddress, src_port: int,
-                 dst_address: IPAddress, dst_port: int,
-                 term: str) -> None:
+                 dst_address: IPAddress, dst_port: int) -> None:
         self.source = f'{src_address}:{src_port}'
         logger.info(
-            "SSH session from %s:%i to %s:%i begun (term: %s)",
+            "SSH session from %s:%i to %s:%i began",
             src_address, src_port,
-            dst_address, dst_port,
-            term)
+            dst_address, dst_port)
+
+    def log_pty_request(self, term: str,
+                        term_width_cols: int, term_height_rows: int,
+                        term_width_pixels: int, term_height_pixels: int) -> None:
+        logger.info("[%s] SSH PTY request: %s (%ix%i cols/rows, %ix%i pixels)",
+                    self.source, term,
+                    term_width_cols, term_height_rows,
+                    term_width_pixels, term_height_pixels)
 
     def log_login_attempt(self, username: str, password: str) -> None:
         logger.info("[%s] Login attempt: %s/%s",

--- a/frontend/frontend/logging/_console.py
+++ b/frontend/frontend/logging/_console.py
@@ -1,0 +1,46 @@
+import logging
+from typing import Optional, Union
+from ipaddress import IPv4Address, IPv6Address
+import hashlib
+from ._types import IPAddress
+
+logger = logging.getLogger(__name__)
+
+
+class SSHSession:
+    """Implementation of logging.Session that merely logs actions to console"""
+
+    source: str
+
+    def __init__(self,
+                 src_address: IPAddress, src_port: int,
+                 dst_address: IPAddress, dst_port: int,
+                 term: str) -> None:
+        self.source = f'{src_address}:{src_port}'
+        logger.info(
+            "SSH session from %s:%i to %s:%i begun (term: %s)",
+            src_address, src_port,
+            dst_address, dst_port,
+            term)
+
+    def log_login_attempt(self, username: str, password: str) -> None:
+        logger.info("[%s] Login attempt: %s/%s",
+                    self.source, username, password)
+
+    def log_command(self, input: str) -> None:
+        logger.info("[%s] Command: %s",
+                    self.source, input)
+
+    def log_download(self,
+                     data: memoryview,
+                     file_type: str,
+                     source_address: Union[IPv4Address, IPv6Address],
+                     source_url: Optional[str] = None,
+                     save_data: bool = True) -> None:
+        logger.info("[%s] Download from %s (%s) of type %s: %s",
+                    self.source, source_address,
+                    source_url, file_type,
+                    hashlib.sha256(data).hexdigest())
+
+    def end(self) -> None:
+        logger.info("SSH session from %s ended", self.source)

--- a/frontend/frontend/logging/_types.py
+++ b/frontend/frontend/logging/_types.py
@@ -1,0 +1,4 @@
+from typing import Union
+from ipaddress import IPv4Address, IPv6Address
+
+IPAddress = Union[IPv4Address, IPv6Address]

--- a/frontend/pyproject.toml
+++ b/frontend/pyproject.toml
@@ -18,7 +18,7 @@ coverage = {extras = ["toml"], version = "^5.4"}
 
 # Pytest
 [tool.pytest.ini_options]
-addopts = "--html=tests_output/report.html --self-contained-html --cov --cov-report=term --cov-report=html"
+addopts = "--doctest-modules --html=tests_output/report.html --self-contained-html --cov --cov-report=term --cov-report=html"
 cache_dir = "tests_output/.pytest_cache"
 
 # Testing coverage


### PR DESCRIPTION
Frontend module for logging attacker sessions and actions.

Example Usage (SSH):
```python
from frontend.logging import begin_ssh_session

with begin_ssh_session(src_address=ip_address('43.56.223.156'),
                       src_port=3463,
                       dst_address=ip_address('226.64.12.2'),
                       dst_port=22) as session:
    session.log_login_attempt('a_username', 'some_password')
    session.log_command('sudo rm -rf /')
    session.log_pty_request('xterm', 5, 20, 600, 200)
```