### PR TITLE
Add more workspace settings for consistent code

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,7 +15,7 @@ ignore=CVS
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
 # Ignore test files 
-ignore-patterns="test_.*?py"
+ignore-patterns=test_.*?py
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/Honeypot.code-workspace
+++ b/Honeypot.code-workspace
@@ -14,7 +14,6 @@
     }
   ],
   "settings": {
-    "editor.codeActionsOnSave": ["source.organizeImports"],
     "python.linting.enabled": true,
     "python.linting.lintOnSave": true,
     "python.linting.pylintEnabled": true,

--- a/Honeypot.code-workspace
+++ b/Honeypot.code-workspace
@@ -14,19 +14,23 @@
     }
   ],
   "settings": {
+    "editor.codeActionsOnSave": ["source.organizeImports"],
     "python.linting.enabled": true,
     "python.linting.lintOnSave": true,
     "python.linting.pylintEnabled": true,
     "python.linting.pylintPath": "pylint",
-    "python.linting.pylintArgs": ["--rcfile=../../.pylintrc"],
+    "python.linting.pylintArgs": ["--rcfile=../.pylintrc"],
     "python.analysis.typeCheckingMode": "basic",
+    "python.analysis.autoImportCompletions": true,
     "editor.formatOnSave": true,
     "python.formatting.provider": "autopep8",
     "python.formatting.autopep8Path": "autopep8",
-    "autoDocstring.docstringFormat": "sphinx",
-    "cSpell.words": [
-      "paramiko"
-    ]
+    "python.formatting.autopep8Args": [
+      "--max-line-length",
+      "100",
+      "--experimental"
+    ],
+    "autoDocstring.docstringFormat": "sphinx"
   },
   "extensions": {
     "recommendations": [

--- a/frontend/tests/protocols/test_ssh.py
+++ b/frontend/tests/protocols/test_ssh.py
@@ -1,10 +1,11 @@
 import time
 from threading import Thread
 
-import frontend.protocols.ssh as ssh
 import paramiko
-import pytest
 from paramiko import SSHClient
+import pytest
+
+import frontend.protocols.ssh as ssh
 
 
 @pytest.fixture()


### PR DESCRIPTION
- ~~Added a setting where imports are organized on save since pylint is picky about what order things are imported in~~
  - It didn't sort according to the order pylint wanted
- Set the line length for autopep8 to 100 since that's what we're using in pylint
- Added the `--experimental` flag to automatically break up lines longer than max line length ([that's the only thing the experimental flag does](https://github.com/hhatto/autopep8#more-advanced-usage))
- Added setting to make it easier to add imports by allowing them to be autocompleted
- Changed the pylintArgs path back to `../.pylintrc`, the reason I changed it last time was because it didn't work but I probably didn't have the workspace open I realize now 🤦‍♂️
- Removed the cSpell.words setting for an extension we don't use. (I accidentally committed it last time cuz im dumb)