### PR TITLE
Add logging of SSH channel output to database schema and logging module

### DIFF
--- a/database/config/tables.sql
+++ b/database/config/tables.sql
@@ -50,6 +50,7 @@ CREATE TABLE EventType
 INSERT INTO EventType VALUES
   ('pty_request'),
   ('command'),
+  ('ssh_channel_output'),
   ('download'),
   ('login_attempt');
 
@@ -102,6 +103,23 @@ CREATE TABLE Command
     REFERENCES Event (id, type),
   CONSTRAINT Check_Correct_Type
     CHECK (event_type = 'command')
+);
+
+CREATE TABLE SSHChannelOutput
+(
+  event_id           int     NOT NULL,
+  event_type         text    NOT NULL DEFAULT 'ssh_channel_output',
+  session_protocol   text    NOT NULL DEFAULT 'ssh',
+  data               bytea   NOT NULL,
+  channel            int     NOT NULL,
+  PRIMARY KEY (event_id, event_type),
+  CONSTRAINT FK_Command_TO_Event
+    FOREIGN KEY (event_id, event_type, session_protocol)
+    REFERENCES Event (id, type, session_protocol),
+  CONSTRAINT Check_Correct_Type
+    CHECK (event_type = 'ssh_channel_output'),
+  CONSTRAINT Check_Correct_Protocol
+    CHECK (session_protocol = 'ssh')
 );
 
 CREATE TABLE Download

--- a/database/design/ER.dia
+++ b/database/design/ER.dia
@@ -2321,5 +2321,197 @@
         <dia:connection handle="1" to="O66" connection="1"/>
       </dia:connections>
     </dia:object>
+    <dia:object type="ER - Entity" version="0" id="O68">
+      <dia:attribute name="obj_pos">
+        <dia:point val="-18.8,45"/>
+      </dia:attribute>
+      <dia:attribute name="obj_bb">
+        <dia:rectangle val="-18.85,44.95;-11.19,46.85"/>
+      </dia:attribute>
+      <dia:attribute name="elem_corner">
+        <dia:point val="-18.8,45"/>
+      </dia:attribute>
+      <dia:attribute name="elem_width">
+        <dia:real val="7.5600000000000005"/>
+      </dia:attribute>
+      <dia:attribute name="elem_height">
+        <dia:real val="1.8"/>
+      </dia:attribute>
+      <dia:attribute name="border_width">
+        <dia:real val="0.10000000000000001"/>
+      </dia:attribute>
+      <dia:attribute name="border_color">
+        <dia:color val="#000000"/>
+      </dia:attribute>
+      <dia:attribute name="inner_color">
+        <dia:color val="#ffffff"/>
+      </dia:attribute>
+      <dia:attribute name="name">
+        <dia:string>#SSHChannelOutput#</dia:string>
+      </dia:attribute>
+      <dia:attribute name="weak">
+        <dia:boolean val="false"/>
+      </dia:attribute>
+      <dia:attribute name="associative">
+        <dia:boolean val="false"/>
+      </dia:attribute>
+      <dia:attribute name="font">
+        <dia:font family="monospace" style="0" name="Courier"/>
+      </dia:attribute>
+      <dia:attribute name="font_height">
+        <dia:real val="0.80000000000000004"/>
+      </dia:attribute>
+    </dia:object>
+    <dia:object type="ER - Attribute" version="0" id="O69">
+      <dia:attribute name="obj_pos">
+        <dia:point val="-15.6,48"/>
+      </dia:attribute>
+      <dia:attribute name="obj_bb">
+        <dia:rectangle val="-15.65,47.95;-10.855,49.85"/>
+      </dia:attribute>
+      <dia:attribute name="elem_corner">
+        <dia:point val="-15.6,48"/>
+      </dia:attribute>
+      <dia:attribute name="elem_width">
+        <dia:real val="4.6950000000000003"/>
+      </dia:attribute>
+      <dia:attribute name="elem_height">
+        <dia:real val="1.8"/>
+      </dia:attribute>
+      <dia:attribute name="border_width">
+        <dia:real val="0.10000000000000001"/>
+      </dia:attribute>
+      <dia:attribute name="border_color">
+        <dia:color val="#000000"/>
+      </dia:attribute>
+      <dia:attribute name="inner_color">
+        <dia:color val="#ffffff"/>
+      </dia:attribute>
+      <dia:attribute name="name">
+        <dia:string>#channel#</dia:string>
+      </dia:attribute>
+      <dia:attribute name="key">
+        <dia:boolean val="false"/>
+      </dia:attribute>
+      <dia:attribute name="weak_key">
+        <dia:boolean val="false"/>
+      </dia:attribute>
+      <dia:attribute name="derived">
+        <dia:boolean val="false"/>
+      </dia:attribute>
+      <dia:attribute name="multivalued">
+        <dia:boolean val="false"/>
+      </dia:attribute>
+      <dia:attribute name="font">
+        <dia:font family="monospace" style="0" name="Courier"/>
+      </dia:attribute>
+      <dia:attribute name="font_height">
+        <dia:real val="0.80000000000000004"/>
+      </dia:attribute>
+    </dia:object>
+    <dia:object type="Standard - Line" version="0" id="O70">
+      <dia:attribute name="obj_pos">
+        <dia:point val="-15.02,46.8"/>
+      </dia:attribute>
+      <dia:attribute name="obj_bb">
+        <dia:rectangle val="-15.0895,46.7305;-13.183,48.0695"/>
+      </dia:attribute>
+      <dia:attribute name="conn_endpoints">
+        <dia:point val="-15.02,46.8"/>
+        <dia:point val="-13.2525,48"/>
+      </dia:attribute>
+      <dia:attribute name="numcp">
+        <dia:int val="1"/>
+      </dia:attribute>
+      <dia:connections>
+        <dia:connection handle="0" to="O68" connection="6"/>
+        <dia:connection handle="1" to="O69" connection="1"/>
+      </dia:connections>
+    </dia:object>
+    <dia:object type="Standard - Line" version="0" id="O71">
+      <dia:attribute name="obj_pos">
+        <dia:point val="13.335,39.2"/>
+      </dia:attribute>
+      <dia:attribute name="obj_bb">
+        <dia:rectangle val="-15.079,39.141;13.394,45.059"/>
+      </dia:attribute>
+      <dia:attribute name="conn_endpoints">
+        <dia:point val="13.335,39.2"/>
+        <dia:point val="-15.02,45"/>
+      </dia:attribute>
+      <dia:attribute name="numcp">
+        <dia:int val="1"/>
+      </dia:attribute>
+      <dia:connections>
+        <dia:connection handle="0" to="O25" connection="2"/>
+        <dia:connection handle="1" to="O68" connection="1"/>
+      </dia:connections>
+    </dia:object>
+    <dia:object type="ER - Attribute" version="0" id="O72">
+      <dia:attribute name="obj_pos">
+        <dia:point val="-20,48"/>
+      </dia:attribute>
+      <dia:attribute name="obj_bb">
+        <dia:rectangle val="-20.05,47.95;-16.41,49.85"/>
+      </dia:attribute>
+      <dia:attribute name="elem_corner">
+        <dia:point val="-20,48"/>
+      </dia:attribute>
+      <dia:attribute name="elem_width">
+        <dia:real val="3.54"/>
+      </dia:attribute>
+      <dia:attribute name="elem_height">
+        <dia:real val="1.8"/>
+      </dia:attribute>
+      <dia:attribute name="border_width">
+        <dia:real val="0.10000000000000001"/>
+      </dia:attribute>
+      <dia:attribute name="border_color">
+        <dia:color val="#000000"/>
+      </dia:attribute>
+      <dia:attribute name="inner_color">
+        <dia:color val="#ffffff"/>
+      </dia:attribute>
+      <dia:attribute name="name">
+        <dia:string>#data#</dia:string>
+      </dia:attribute>
+      <dia:attribute name="key">
+        <dia:boolean val="false"/>
+      </dia:attribute>
+      <dia:attribute name="weak_key">
+        <dia:boolean val="false"/>
+      </dia:attribute>
+      <dia:attribute name="derived">
+        <dia:boolean val="false"/>
+      </dia:attribute>
+      <dia:attribute name="multivalued">
+        <dia:boolean val="false"/>
+      </dia:attribute>
+      <dia:attribute name="font">
+        <dia:font family="monospace" style="0" name="Courier"/>
+      </dia:attribute>
+      <dia:attribute name="font_height">
+        <dia:real val="0.80000000000000004"/>
+      </dia:attribute>
+    </dia:object>
+    <dia:object type="Standard - Line" version="0" id="O73">
+      <dia:attribute name="obj_pos">
+        <dia:point val="-15.02,46.8"/>
+      </dia:attribute>
+      <dia:attribute name="obj_bb">
+        <dia:rectangle val="-18.2943,46.7357;-14.9557,48.0643"/>
+      </dia:attribute>
+      <dia:attribute name="conn_endpoints">
+        <dia:point val="-15.02,46.8"/>
+        <dia:point val="-18.23,48"/>
+      </dia:attribute>
+      <dia:attribute name="numcp">
+        <dia:int val="1"/>
+      </dia:attribute>
+      <dia:connections>
+        <dia:connection handle="0" to="O68" connection="6"/>
+        <dia:connection handle="1" to="O72" connection="1"/>
+      </dia:connections>
+    </dia:object>
   </dia:layer>
 </dia:diagram>

--- a/database/migrations/1_add_ssh_channel_output_event.sql
+++ b/database/migrations/1_add_ssh_channel_output_event.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+INSERT INTO EventType VALUES
+  ('ssh_channel_output');
+
+CREATE TABLE SSHChannelOutput
+(
+  event_id           int     NOT NULL,
+  event_type         text    NOT NULL DEFAULT 'ssh_channel_output',
+  session_protocol   text    NOT NULL DEFAULT 'ssh',
+  data               bytea   NOT NULL,
+  channel            int     NOT NULL,
+  PRIMARY KEY (event_id, event_type),
+  CONSTRAINT FK_Command_TO_Event
+    FOREIGN KEY (event_id, event_type, session_protocol)
+    REFERENCES Event (id, type, session_protocol),
+  CONSTRAINT Check_Correct_Type
+    CHECK (event_type = 'ssh_channel_output'),
+  CONSTRAINT Check_Correct_Protocol
+    CHECK (session_protocol = 'ssh')
+);
+
+COMMIT;

--- a/frontend/frontend/honeylogger/__init__.py
+++ b/frontend/frontend/honeylogger/__init__.py
@@ -43,6 +43,15 @@ class Session(Protocol):
         raise NotImplementedError
 
     @abstractmethod
+    def log_ssh_channel_output(self, data: memoryview, channel: int) -> None:
+        """Logs a new block of output associated with the current session and SSH channel.
+
+        :param data: The raw bytes that were output.
+        :param channel: The SSH channel the data was output on. 
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def log_download(self,
                      data: memoryview,
                      file_type: str,

--- a/frontend/frontend/honeylogger/_console.py
+++ b/frontend/frontend/honeylogger/_console.py
@@ -45,6 +45,10 @@ class ConsoleLogSSHSession():
         logger.info("[%s] Command: %s",
                     self.source, input)
 
+    def log_ssh_channel_output(self, data: memoryview, channel: int) -> None:
+        logger.info("[%s] Output recieved on channel %d",
+                    self.source, channel)
+
     def log_download(self,
                      data: memoryview,
                      file_type: str,

--- a/frontend/frontend/honeylogger/_postgres.py
+++ b/frontend/frontend/honeylogger/_postgres.py
@@ -102,6 +102,20 @@ class PostgresLogSSHSession:
         finally:
             conn.close()
 
+    def log_ssh_channel_output(self, data: memoryview, channel: int) -> None:
+        conn = db.connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    event_id = insert_new_event(
+                        cur, self.session_id, 'ssh_channel_output')
+                    cur.execute("""
+                        INSERT INTO SSHChannelOutput (event_id, data, channel)
+                            VALUES (%s, %s, %s)
+                        """, (event_id, data, channel))
+        finally:
+            conn.close()
+
     def log_download(self,
                      data: memoryview,
                      file_type: str,

--- a/frontend/tests/logging/test_postgres.py
+++ b/frontend/tests/logging/test_postgres.py
@@ -15,5 +15,9 @@ def test_no_runtime_errors():
                          'text/plain',
                          ip_address('2.43.12.243'),
                          'https://google.com/hello.txt')
+    session.log_ssh_channel_output(memoryview(b'ls\noutput of ls....\n'), 1)
+    session.log_ssh_channel_output(memoryview(b'more output of ls\n'), 1)
+    session.log_ssh_channel_output(memoryview(b'SOME COMMAND ONE SECOND CHANNEL\n'), 2)
+    session.log_ssh_channel_output(memoryview(b'output on second channel\n'), 2)
 
     session.end()


### PR DESCRIPTION
As a preliminary way of logging "commands" over SSH we could log the whole output log of every SSH channel.
This PR adds the required setup for this in the database and logging module.

To deploy this in production, the file `database\migrations\1_add_ssh_channel_output_event.sql` needs to be run.