### PR TITLE
Frontend backend integration

### DIFF
--- a/backend/backend/__main__.py
+++ b/backend/backend/__main__.py
@@ -1,7 +1,6 @@
 """Main entrypoint for backend."""
 
 import logging
-import urllib.request
 import backend.container as container
 import backend.http_server as server
 import backend.config as config
@@ -13,17 +12,16 @@ def main():
     # Configure logging
     logging.basicConfig(level=logging.INFO)
 
-    # Find public server IP
-    # TODO: Is there any better way to get the public facing ip?
-    public_address = urllib.request.urlopen('https://ident.me').read().decode('utf-8')
-
     # Setup container management
     container_handler = container.Containers()
+
+    if config.TARGET_SYSTEM_ADDRESS is None:
+        raise TypeError('Environment variable TARGET_SYSTEM_ADDRESS must be set')
 
     # Run HTTP server
     http_server = server.start_http_server(
         container_handler,
-        public_address,
+        target_system_address=config.TARGET_SYSTEM_ADDRESS,
         bind_address=config.HTTP_API_BIND_ADDRESS)
     http_server.wait_for_termination()
 

--- a/backend/backend/config.py
+++ b/backend/backend/config.py
@@ -4,5 +4,8 @@ import os
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
-
+# The interface and port the HTTP API should listen on
 HTTP_API_BIND_ADDRESS = os.getenv('HTTP_API_BIND_ADDRESS', '0.0.0.0:80')
+
+# The address to use when connecting to acquired target systems
+TARGET_SYSTEM_ADDRESS = os.getenv('TARGET_SYSTEM_ADDRESS')

--- a/backend/backend/http_server.py
+++ b/backend/backend/http_server.py
@@ -20,11 +20,11 @@ class TargetSystemProvider(tsp.TargetSystemProviderServicer):
     """Implementation of gRPC TargetSystemProvider service"""
 
     container_handler: Containers
-    public_address: str
+    target_system_address: str
 
-    def __init__(self, container_handler: Containers, public_address: str):
+    def __init__(self, container_handler: Containers, target_system_address: str):
         self.container_handler = container_handler
-        self.public_address = public_address
+        self.target_system_address = target_system_address
 
     def AcquireTargetSystem(self, request, context):
         container_id = uuid.uuid4().int % (2**32)
@@ -45,7 +45,7 @@ class TargetSystemProvider(tsp.TargetSystemProviderServicer):
 
         return messages.AcquisitionResult(
             id=config['ID'],
-            address=self.public_address,
+            address=self.target_system_address,
             port=assigned_port)
 
     def YieldTargetSystem(self, request, context):
@@ -62,7 +62,7 @@ class TargetSystemProvider(tsp.TargetSystemProviderServicer):
 
 
 def start_http_server(container_handler: Containers,
-                      public_address: str,
+                      target_system_address: str,
                       bind_address: str = 'localhost:80') -> grpc.Server:
     """Starts a gRPC HTTP server with pre-configured services.
 
@@ -76,7 +76,7 @@ def start_http_server(container_handler: Containers,
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     tsp.add_TargetSystemProviderServicer_to_server(
-        TargetSystemProvider(container_handler, public_address), server)
+        TargetSystemProvider(container_handler, target_system_address), server)
     server.add_insecure_port(bind_address)  # TODO: ADD TLS!
     server.start()
 

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -28,6 +28,8 @@ services:
     build:
       context: ..
       dockerfile: frontend/Dockerfile
+    environment:
+      BACKEND_ADDRESS: "backend:80"
     ports:
       - "22:22"
     volumes:
@@ -43,6 +45,8 @@ services:
     build:
       context: ..
       dockerfile: backend/Dockerfile
+    environment:
+      TARGET_SYSTEM_ADDRESS: "host.docker.internal"
     ports:
       - "80:80"
     volumes:

--- a/frontend/frontend/__main__.py
+++ b/frontend/frontend/__main__.py
@@ -5,20 +5,21 @@ import paramiko
 from frontend.protocols.ssh import ConnectionManager as SSHConnectionManager
 from frontend.config import config
 import frontend.protocols.ssh
+from frontend.target_systems import create_grpc_target_system_provider
 
 logger = logging.getLogger(__name__)
 
 
-def main() -> None:
-    """Entrypoint for the honeypot frontend"""
-
-    # Set up logging
+def setup_logging():
     root_logger = logging.getLogger()
+
+    # Console handler
     coloredlogs.install(
-        logging.INFO, logger=root_logger,
+        logging.NOTSET, logger=root_logger,
         fmt='%(asctime)s %(levelname)-8s %(message)s (%(threadName)s, %(name)s)',
         datefmt='%Y-%m-%d %H:%M:%S')
 
+    # File handler
     file_formatter = logging.Formatter(
         fmt='%(asctime)s %(levelname)-8s %(message)s (%(threadName)s, %(name)s)',
         datefmt='%Y-%m-%d %H:%M:%S')
@@ -26,14 +27,32 @@ def main() -> None:
     file_handler.setFormatter(file_formatter)
     root_logger.addHandler(file_handler)
 
+    # Log levels
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
     if config.SSH_ENABLE_DEBUG_LOGGING:
         ssh_logger = logging.getLogger(frontend.protocols.ssh.__name__)
         ssh_logger.setLevel(logging.DEBUG)
 
+
+def main() -> None:
+    """Entrypoint for the honeypot frontend"""
+
+    # Set up logging
+    setup_logging()
+
+    # Create the target system provider to use for all attacker connections
+    if config.BACKEND_ADDRESS is None:
+        raise TypeError('Environment variable BACKEND_ADDRESS must be set')
+    logger.info('Using backend with address: %s', config.BACKEND_ADDRESS)
+    target_system_provider = create_grpc_target_system_provider(config.BACKEND_ADDRESS)
+
     # Start SSH server
     logger.info('Starting SSH server...')
     key = paramiko.RSAKey(filename='./host.key')
-    server = SSHConnectionManager(host_key=key,
+    server = SSHConnectionManager(target_system_provider=target_system_provider,
+                                  host_key=key,
                                   port=config.SSH_SERVER_PORT,
                                   socket_timeout=config.SSH_SOCKET_TIMEOUT,
                                   max_unaccepted_connetions=config.SSH_MAX_UNACCEPTED_CONNECTIONS,

--- a/frontend/frontend/config/config.py
+++ b/frontend/frontend/config/config.py
@@ -34,4 +34,6 @@ SSH_ENABLE_DEBUG_LOGGING = bool(os.getenv('ENABLE_DEBUG_LOGGING', 'False'))
 # Log file for SSH if debug logging is enabled
 SSH_LOG_FILE = os.getenv('SSH_LOG_FILE', './honeypot.log')
 
-BACKEND_IP = os.getenv('BACKEND_IP')
+# The address to a host running a server supporting the target_system_provider gRCP protocol
+# Example: localhost:80
+BACKEND_ADDRESS = os.getenv('BACKEND_ADDRESS')

--- a/frontend/frontend/database/connect.py
+++ b/frontend/frontend/database/connect.py
@@ -18,3 +18,4 @@ def connect():
         return conn
     except (Exception, psycopg2.DatabaseError):
         logger.exception('Failed to connect to Postgres database')
+        raise

--- a/frontend/frontend/protocols/ssh/_ssh_server.py
+++ b/frontend/frontend/protocols/ssh/_ssh_server.py
@@ -64,6 +64,7 @@ class Server(paramiko.ServerInterface):
         if self._usernames is not None and not username in self._usernames:
             return AUTH_FAILED
         if self._passwords is None or password in self._passwords:
+            self._proxy_handler.set_attacker_credentials(username, password)
             return AUTH_SUCCESSFUL
         return AUTH_FAILED
 

--- a/frontend/frontend/protocols/ssh/_ssh_server.py
+++ b/frontend/frontend/protocols/ssh/_ssh_server.py
@@ -23,7 +23,8 @@ class Server(paramiko.ServerInterface):
     _channels_done: Set[int]
 
     def __init__(
-            self, session: SSHSession,
+            self,
+            session: SSHSession,
             proxy_handler: ProxyHandler,
             usernames: Optional[List[str]],
             passwords: Optional[List[str]]) -> None:
@@ -78,9 +79,8 @@ class Server(paramiko.ServerInterface):
         self._update_last_activity()
         logger.info("Attacker requested a channel with the id %s and kind %s", chanid, kind)
         if kind == "session":
-            return self._proxy_handler.create_backend_connection(
-                "", "") and self._proxy_handler.open_channel(
-                kind, chanid)
+            return (self._proxy_handler.create_backend_connection()
+                    and self._proxy_handler.open_channel(kind, chanid))
 
         return OPEN_SUCCEEDED
 

--- a/frontend/frontend/target_systems/__init__.py
+++ b/frontend/frontend/target_systems/__init__.py
@@ -9,18 +9,11 @@ from ._grpc import _GrpcTargetSystemProvider
 __all__ = ['TargetSystem', 'TargetSystemProvider', 'create_grpc_target_system_provider']
 
 
-@contextmanager
-def create_grpc_target_system_provider(server_address: str) -> Iterator[TargetSystemProvider]:
+def create_grpc_target_system_provider(server_address: str) -> TargetSystemProvider:
     """Factory for a TargetSystemProvider that connects to a remote gRPC service.
-
-    Should be used in a with-statement to open and close connection channel.
 
     :param server_address: The address of the gRPC server.
     :return: The constructed TargetSystemProvider.
     """
 
-    provider = _GrpcTargetSystemProvider(server_address)
-    try:
-        yield provider
-    finally:
-        provider.close_channel()
+    return _GrpcTargetSystemProvider(server_address)

--- a/frontend/tests/protocols/ssh/test_connection_manager.py
+++ b/frontend/tests/protocols/ssh/test_connection_manager.py
@@ -1,18 +1,25 @@
 import socket
 import time
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch, create_autospec
 
 import pytest
 
 import paramiko
 from frontend.protocols.ssh.connection_manager import ConnectionManager
 from frontend.protocols.ssh._transport_manager import TransportManager
+from frontend.target_systems import TargetSystemProvider
 
 
 @pytest.fixture()
 def connection_manager() -> ConnectionManager:
     key = paramiko.RSAKey(filename="./host.key")
-    return ConnectionManager(key, [""], [""], port=2222, socket_timeout=0.2)
+    return ConnectionManager(
+        create_autospec(TargetSystemProvider),
+        key,
+        [""],
+        [""],
+        port=2222,
+        socket_timeout=0.2)
 
 
 def test_shutdown(connection_manager: ConnectionManager):

--- a/frontend/tests/protocols/ssh/test_proxy_handler.py
+++ b/frontend/tests/protocols/ssh/test_proxy_handler.py
@@ -4,7 +4,7 @@ import logging
 import threading
 import socket
 from ipaddress import ip_address
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 import paramiko
@@ -13,6 +13,7 @@ from frontend.protocols.ssh._proxy_handler import ProxyHandler, try_send_data, p
 from frontend.honeylogger import SSHSession
 from frontend.honeylogger._console import ConsoleLogSSHSession
 import frontend.protocols.ssh._proxy_handler
+from frontend.target_systems import TargetSystemProvider
 
 debug_log = frontend.protocols.ssh._proxy_handler.logger
 
@@ -20,6 +21,11 @@ debug_log = frontend.protocols.ssh._proxy_handler.logger
 @pytest.fixture()
 def logger() -> SSHSession:
     return ConsoleLogSSHSession(ip_address("1.1.1.1"), 1, ip_address("2.2.2.2"), 2)
+
+
+@pytest.fixture()
+def target_system_provider(logger) -> ProxyHandler:
+    return create_autospec(TargetSystemProvider)
 
 
 def test_try_send_data():
@@ -36,68 +42,72 @@ def test_try_send_data():
 
 
 @patch.object(paramiko.SSHClient, 'connect', return_value=None)
-def test_error_transport_none_connect(connect_mock, logger):
+def test_error_transport_none_connect(connect_mock, logger, target_system_provider):
     debug_log.exception = MagicMock()
     debug_log.error = MagicMock()
 
-    p = ProxyHandler(logger)
-    p._open_proxy_transport("", 0, "", "")
+    p = ProxyHandler(logger, target_system_provider)
+    p._open_proxy_transport("", 0, "", "", max_retries=0)
 
-    connect_mock.assert_called_once_with("", port=0, username="", password="")
-    debug_log.error.assert_called_once()
-    debug_log.exception.assert_not_called()
+    connect_mock.assert_called_once_with("", port=0, username="", password="",
+                                         allow_agent=False, look_for_keys=False)
+    debug_log.error.assert_not_called()
+    debug_log.exception.assert_called_once()
 
 
 @patch.object(paramiko.SSHClient, 'get_transport', return_value=1)
 @patch.object(paramiko.SSHClient, 'connect', return_value=None)
-def test_connect(connect_mock, get_transport_mock, logger):
+def test_connect(connect_mock, get_transport_mock, logger, target_system_provider):
     debug_log.exception = MagicMock()
     debug_log.error = MagicMock()
 
-    p = ProxyHandler(logger)
-    p._open_proxy_transport("", 0, "", "")
+    p = ProxyHandler(logger, target_system_provider)
+    result = p._open_proxy_transport("", 0, "", "", max_retries=0)
 
-    connect_mock.assert_called_once_with("", port=0, username="", password="")
+    connect_mock.assert_called_once_with("", port=0, username="", password="",
+                                         allow_agent=False, look_for_keys=False)
     debug_log.error.assert_not_called()
     debug_log.exception.assert_not_called()
-    assert p._backend_connection_active
+    assert result is not None
 
 
 @patch.object(paramiko.SSHClient, 'connect', side_effect=paramiko.SSHException)
-def test_ssh_exception(connect_mock, logger):
+def test_ssh_exception(connect_mock, logger, target_system_provider):
     debug_log.exception = MagicMock()
 
-    p = ProxyHandler(logger)
-    p._open_proxy_transport("", 0, "", "")
+    p = ProxyHandler(logger, target_system_provider)
+    p._open_proxy_transport("", 0, "", "", max_retries=0)
 
-    connect_mock.assert_called_once_with("", port=0, username="", password="")
+    connect_mock.assert_called_once_with("", port=0, username="", password="",
+                                         allow_agent=False, look_for_keys=False)
     debug_log.exception.assert_called_once()
 
 
 @patch.object(paramiko.SSHClient, 'connect', side_effect=socket.error)
-def test_socket_error(connect_mock, logger):
+def test_socket_error(connect_mock, logger, target_system_provider):
     debug_log.exception = MagicMock()
 
-    p = ProxyHandler(logger)
-    p._open_proxy_transport("", 0, "", "")
+    p = ProxyHandler(logger, target_system_provider)
+    p._open_proxy_transport("", 0, "", "", max_retries=0)
 
-    connect_mock.assert_called_once_with("", port=0, username="", password="")
+    connect_mock.assert_called_once_with("", port=0, username="", password="",
+                                         allow_agent=False, look_for_keys=False)
     debug_log.exception.assert_called_once()
 
 
-def test_get_corresponding_backend_channel_error(logger):
-    p = ProxyHandler(logger)
+def test_get_corresponding_backend_channel_error(logger, target_system_provider):
+    p = ProxyHandler(logger, target_system_provider)
 
     # No such channel available
     with pytest.raises(KeyError):
         p._get_corresponding_backend_channel(1)
 
 
-def test_get_corresponding_backend_channel_ok(logger):
+def test_get_corresponding_backend_channel_ok(logger, target_system_provider):
     debug_log.error = MagicMock()
     debug_log.exception = MagicMock()
 
-    p = ProxyHandler(logger)
+    p = ProxyHandler(logger, target_system_provider)
     c = paramiko.Channel(0)
     p._backend_chan_proxies[1] = c
 
@@ -107,17 +117,17 @@ def test_get_corresponding_backend_channel_ok(logger):
     debug_log.error.assert_not_called()
 
 
-def test_handle_exec_keyerror(logger):
-    p = ProxyHandler(logger)
+def test_handle_exec_keyerror(logger, target_system_provider):
+    p = ProxyHandler(logger, target_system_provider)
     p._get_corresponding_backend_channel = MagicMock(side_effect=KeyError)
 
     assert p.handle_exec_request(paramiko.Channel(0), b"") == False
 
 
-def test_handle_exec_unicodeerror(logger):
+def test_handle_exec_unicodeerror(logger, target_system_provider):
     debug_log.error = MagicMock()
 
-    p = ProxyHandler(logger)
+    p = ProxyHandler(logger, target_system_provider)
     p._get_corresponding_backend_channel = MagicMock(
         side_effect=UnicodeDecodeError("", b"", 0, 0, ""))
 
@@ -125,10 +135,10 @@ def test_handle_exec_unicodeerror(logger):
     debug_log.error.assert_called_once()
 
 
-def test_handle_exec_error(logger):
+def test_handle_exec_error(logger, target_system_provider):
     debug_log.error = MagicMock()
 
-    p = ProxyHandler(logger)
+    p = ProxyHandler(logger, target_system_provider)
 
     channel_mock = MagicMock()
     channel_mock.exec_command.side_effect = paramiko.SSHException
@@ -139,11 +149,11 @@ def test_handle_exec_error(logger):
     debug_log.error.assert_called_once()
 
 
-def test_handle_exec_ok(logger):
+def test_handle_exec_ok(logger, target_system_provider):
     with patch("threading.Thread"):
         debug_log.error = MagicMock()
         logger.log_command = MagicMock()
-        p = ProxyHandler(logger)
+        p = ProxyHandler(logger, target_system_provider)
 
         channel_mock = MagicMock()
         channel_mock.exec_command = MagicMock()
@@ -156,29 +166,29 @@ def test_handle_exec_ok(logger):
         logger.log_command.assert_called_once()
 
 
-def test_shell_request_keyerror(logger):
-    p = ProxyHandler(logger)
+def test_shell_request_keyerror(logger, target_system_provider):
+    p = ProxyHandler(logger, target_system_provider)
     p._get_corresponding_backend_channel = MagicMock(side_effect=KeyError)
 
     assert p.handle_shell_request(paramiko.Channel(0)) == False
 
 
-def test_shell_request_sshexception(logger):
+def test_shell_request_sshexception(logger, target_system_provider):
     debug_log.error = MagicMock()
-    p = ProxyHandler(logger)
+    p = ProxyHandler(logger, target_system_provider)
     p._get_corresponding_backend_channel = MagicMock(side_effect=paramiko.SSHException)
 
     assert p.handle_shell_request(paramiko.Channel(0)) == False
     debug_log.error.assert_called_once()
 
 
-def test_shell_request_ok(logger):
+def test_shell_request_ok(logger, target_system_provider):
     with patch("threading.Thread"):
         debug_log.error = MagicMock()
 
         backend_mock = MagicMock()
         backend_mock.invoke_shell = MagicMock()
-        p = ProxyHandler(logger)
+        p = ProxyHandler(logger, target_system_provider)
         p._get_corresponding_backend_channel = MagicMock(return_value=backend_mock)
 
         assert p.handle_shell_request(paramiko.Channel(0))
@@ -186,10 +196,10 @@ def test_shell_request_ok(logger):
         backend_mock.invoke_shell.assert_called_once()
 
 
-def test_close_connection_not_active(logger):
+def test_close_connection_not_active(logger, target_system_provider):
     logger.end = MagicMock()
-    p = ProxyHandler(logger)
-    p._backend_connection_active = False
+    p = ProxyHandler(logger, target_system_provider)
+    p._connection = None
     p.close_connection()
 
     logger.end.assert_called_once()

--- a/frontend/tests/protocols/ssh/test_ssh_server.py
+++ b/frontend/tests/protocols/ssh/test_ssh_server.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import pytest
 from ipaddress import ip_address
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import paramiko
 from paramiko.common import (AUTH_FAILED, AUTH_SUCCESSFUL, )
@@ -12,6 +12,7 @@ from frontend.honeylogger import SSHSession
 from frontend.honeylogger._console import ConsoleLogSSHSession
 from frontend.protocols.ssh._ssh_server import Server
 import frontend.protocols.ssh._ssh_server
+from frontend.target_systems import TargetSystemProvider
 
 debug_log = logging.getLogger(frontend.protocols.ssh._ssh_server.__name__)
 
@@ -29,8 +30,13 @@ def logger() -> SSHSession:
 
 
 @pytest.fixture()
-def proxy_handler(logger) -> ProxyHandler:
-    return ProxyHandler(logger)
+def target_system_provider(logger) -> ProxyHandler:
+    return create_autospec(TargetSystemProvider)
+
+
+@pytest.fixture()
+def proxy_handler(logger, target_system_provider) -> ProxyHandler:
+    return ProxyHandler(logger, target_system_provider)
 
 
 @pytest.fixture()

--- a/frontend/tests/target_systems/test_grpc.py
+++ b/frontend/tests/target_systems/test_grpc.py
@@ -6,7 +6,7 @@ import grpc
 import target_system_provider.target_system_provider_pb2_grpc as tsp
 import target_system_provider.target_system_provider_pb2 as messages
 from frontend.target_systems import create_grpc_target_system_provider, TargetSystemProvider
-from frontend.target_systems._grpc import _GrpcTargetSystem
+from frontend.target_systems._grpc import _GrpcTargetSystem, _GrpcTargetSystemProvider
 
 
 @pytest.fixture
@@ -36,8 +36,9 @@ def grpc_server(server_target_system_provider: tsp.TargetSystemProviderServicer)
 
 @pytest.fixture
 def client_target_system_provider():
-    with create_grpc_target_system_provider('localhost:50051') as provider:
-        yield provider
+    provider = create_grpc_target_system_provider('localhost:50051')
+    yield provider
+    cast(_GrpcTargetSystemProvider, provider).close_channel()
 
 
 def test_create_grpc_not_None():


### PR DESCRIPTION
- Frontend now asks backend for a target system after attacker logs in.
- When frontend closes proxy connection (for any reason), target system is yielded back to backend.
- Backend address is configurable through `BACKEND_ADDRESS` env var in frontend.
- The returned target system address from backend is configurable through env var `TARGET_SYSTEM_ADDRESS`.
- Backend now waits until target container is fully ready before responding to an acquisition request. This decreases delays caused by the frontend failing and retrying connections to target container.
- If the frontend, for some reason, fails to connect to target container, it will retry the connection with a delay inbetween.

Some issues:
- Connecting with a blank password currently does not work. It seems like Paramiko does not support it very well and the target container is not configured to accept blank passwords.
- Hostname `host.docker.internal` in `dev/docker-compose.yml` does not work on Linux but on Docker Desktop.

How to test:
- Run `docker-compose up` in `dev` folder
- Connect using SSH to frontend `ssh localhost`
- Make sure you can connect, target container starts and you can run commands etc.