### PR TITLE
Add more logging

### DIFF
--- a/database/config/tables.sql
+++ b/database/config/tables.sql
@@ -19,7 +19,6 @@ CREATE TABLE NetworkSource
 CREATE TABLE Session
 (
   id              serial    NOT NULL,
-  ssh_version     text      NOT NULL,
   attack_src      inet      NOT NULL,
   protocol        text      NOT NULL,
   src_port        int       NOT NULL,
@@ -38,6 +37,19 @@ CREATE TABLE Session
     CHECK (src_port BETWEEN 0 AND 65535 AND dst_port BETWEEN 0 AND 65535),
   CONSTRAINT Check_End_Timestamp_Is_After_Start
     CHECK (CASE WHEN end_timestamp IS NOT NULL THEN start_timestamp <= end_timestamp else TRUE END)
+);
+
+CREATE TABLE SSHSession
+(
+  session_id          int    NOT NULL,
+  session_protocol    text   NOT NULL DEFAULT 'ssh',
+  ssh_version         text   NOT NULL,
+  PRIMARY KEY (session_id),
+  CONSTRAINT FK_SSHSession_TO_Session
+    FOREIGN KEY (session_id, session_protocol)
+    REFERENCES Session (id, protocol),
+  CONSTRAINT Check_Correct_Protocol
+    CHECK (session_protocol = 'ssh')
 );
 
 CREATE TABLE EventType

--- a/database/config/tables.sql
+++ b/database/config/tables.sql
@@ -19,6 +19,7 @@ CREATE TABLE NetworkSource
 CREATE TABLE Session
 (
   id              serial    NOT NULL,
+  ssh_version     text      NOT NULL,
   attack_src      inet      NOT NULL,
   protocol        text      NOT NULL,
   src_port        int       NOT NULL,

--- a/database/config/tables.sql
+++ b/database/config/tables.sql
@@ -49,6 +49,10 @@ CREATE TABLE EventType
 
 INSERT INTO EventType VALUES
   ('pty_request'),
+  ('env_request'),
+  ('direct_tcpip_request'),
+  ('x_eleven_request'),
+  ('port_forward_request'),
   ('command'),
   ('ssh_channel_output'),
   ('download'),
@@ -88,6 +92,81 @@ CREATE TABLE PTYRequest
     REFERENCES Event (id, type, session_protocol),
   CONSTRAINT Check_Correct_Type
     CHECK (event_type = 'pty_request'),
+  CONSTRAINT Check_Correct_Protocol
+    CHECK (session_protocol = 'ssh')
+);
+
+CREATE TABLE EnvRequest
+(
+  event_id            int   NOT NULL,
+  event_type          text  NOT NULL DEFAULT 'env_request',
+  session_protocol    text  NOT NULL DEFAULT 'ssh',
+  channel_id          int   NOT NULL,
+  name                text  NOT NULL,
+  value               text  NOT NULL,
+  PRIMARY KEY (event_id, event_type),
+  CONSTRAINT FK_EnvRequest_TO_Event
+    FOREIGN KEY (event_id, event_type, session_protocol)
+    REFERENCES Event (id, type, session_protocol),
+  CONSTRAINT Check_Correct_Type
+    CHECK (event_type = 'env_request'),
+  CONSTRAINT Check_Correct_Protocol
+    CHECK (session_protocol = 'ssh')
+);
+
+CREATE TABLE DirectTCPIPRequest
+(
+  event_id            int   NOT NULL,
+  event_type          text  NOT NULL DEFAULT 'direct_tcpip_request',
+  session_protocol    text  NOT NULL DEFAULT 'ssh',
+  channel_id          int   NOT NULL,
+  origin_ip           inet  NOT NULL,
+  origin_port         int   NOT NULL,
+  destination         text  NOT NULL,
+  destination_port    int   NOT NULL,
+  PRIMARY KEY (event_id, event_type),
+  CONSTRAINT FK_DirectTCPIPRequest_TO_Event
+    FOREIGN KEY (event_id, event_type, session_protocol)
+    REFERENCES Event (id, type, session_protocol),
+  CONSTRAINT Check_Correct_Type
+    CHECK (event_type = 'direct_tcpip_request'),
+  CONSTRAINT Check_Correct_Protocol
+    CHECK (session_protocol = 'ssh')
+);
+
+CREATE TABLE XElevenRequest
+(
+  event_id            int     NOT NULL,
+  event_type          text    NOT NULL DEFAULT 'x_eleven_request',
+  session_protocol    text    NOT NULL DEFAULT 'ssh',
+  channel_id          int     NOT NULL,
+  single_connection   boolean NOT NULL,
+  auth_protocol       text    NOT NULL,
+  auth_cookie         bytea   NOT NULL,
+  screen_number       int     NOT NULL,
+  PRIMARY KEY (event_id, event_type),
+  CONSTRAINT FK_XElevenRequest_TO_Event
+    FOREIGN KEY (event_id, event_type, session_protocol)
+    REFERENCES Event (id, type, session_protocol),
+  CONSTRAINT Check_Correct_Type
+    CHECK (event_type = 'x_eleven_request'),
+  CONSTRAINT Check_Correct_Protocol
+    CHECK (session_protocol = 'ssh')
+);
+
+CREATE TABLE PortForwardRequest
+(
+  event_id            int     NOT NULL,
+  event_type          text    NOT NULL DEFAULT 'port_forward_request',
+  session_protocol    text    NOT NULL DEFAULT 'ssh',
+  address             text    NOT NULL,
+  port                int     NOT NULL,
+  PRIMARY KEY (event_id, event_type),
+  CONSTRAINT FK_PortForwardRequest_TO_Event
+    FOREIGN KEY (event_id, event_type, session_protocol)
+    REFERENCES Event (id, type, session_protocol),
+  CONSTRAINT Check_Correct_Type
+    CHECK (event_type = 'port_forward_request'),
   CONSTRAINT Check_Correct_Protocol
     CHECK (session_protocol = 'ssh')
 );

--- a/frontend/frontend/honeylogger/__init__.py
+++ b/frontend/frontend/honeylogger/__init__.py
@@ -89,6 +89,53 @@ class SSHSession(Session, Protocol):
         raise NotImplementedError
 
     @abstractmethod
+    def log_env_request(self, chan_id: int, name: str, value: str) -> None:
+        """Logs an SSH env request
+
+        :param chan_id: The channel number the request arrived on
+        :param name: Name of the variable
+        :param value: Value of the variable
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_direct_tcpip_request(
+            self, chan_id: int, origin_ip: IPAddress, origin_port: int,
+            destination: str, destination_port: int) -> None:
+        """Logs an SSH direct tcpip request
+
+        :param chan_id: The channel that was requested
+        :param origin_ip: The origin ip that was requested
+        :param origin_port: The origin port that was requested
+        :param destination: The destinatioin that was requested
+        :param destination_port: The destination port that was requested
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_x11_request(
+            self, chan_id: int, single_connection: bool, auth_protocol: str,
+            auth_cookie: memoryview, screen_number: int) -> None:
+        """Logs an SSH X11 request
+
+        :param chan_id: The channel number that the request arrived on
+        :param single_connection: True if only a single X11 connection should be opened
+        :param auth_protocol: The protocol used for X11 authentication
+        :param auth_cookie: The cookie used to authenticate X11
+        :param screen_number: The number of the X11 screen to connect to
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_port_forward_request(self, address: str, port: int) -> None:
+        """Logs an SSH port forward request
+
+        :param address: The requested address
+        :param port: The requested port
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def log_ssh_channel_output(self, data: memoryview, channel: int) -> None:
         """Logs a new block of output associated with the current session and SSH channel.
 

--- a/frontend/frontend/honeylogger/__init__.py
+++ b/frontend/frontend/honeylogger/__init__.py
@@ -25,11 +25,8 @@ class Session(Protocol):
     """Representation of an attacker's session while being connected to the honeypot."""
 
     @abstractmethod
-    def begin(self, ssh_version: str) -> None:
-        """Begins the logging session
-
-        :param ssh_version: The SSH version of the client connecting
-        """
+    def begin(self) -> None:
+        """Begins the logging session"""
         raise NotImplementedError
 
     @abstractmethod
@@ -76,6 +73,14 @@ class Session(Protocol):
 
 class SSHSession(Session, Protocol):
     """Representation of an attacker's SSH session while being connected to the honeypot."""
+
+    @abstractmethod
+    def set_remote_version(self, ssh_version: str) -> None:
+        """Set the remote SSH version
+
+        :param ssh_version: The SSH version of the client connecting
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def log_pty_request(self, term: str,

--- a/frontend/frontend/honeylogger/__init__.py
+++ b/frontend/frontend/honeylogger/__init__.py
@@ -25,8 +25,11 @@ class Session(Protocol):
     """Representation of an attacker's session while being connected to the honeypot."""
 
     @abstractmethod
-    def begin(self) -> None:
-        """Begins the logging session"""
+    def begin(self, ssh_version: str) -> None:
+        """Begins the logging session
+
+        :param ssh_version: The SSH version of the client connecting
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/frontend/frontend/honeylogger/_console.py
+++ b/frontend/frontend/honeylogger/_console.py
@@ -11,6 +11,7 @@ class ConsoleLogSSHSession():
     """Implementation of honeylogger.SSHSession that merely logs actions to console"""
 
     source: str
+    ssh_version: str
     src_address: str
     src_port: int
     dst_address: str
@@ -25,10 +26,13 @@ class ConsoleLogSSHSession():
         self.dst_address = str(dst_address)
         self.dst_port = dst_port
 
-    def begin(self, ssh_version: str) -> None:
+    def set_remote_version(self, ssh_version: str) -> None:
+        self.ssh_version = ssh_version
+
+    def begin(self) -> None:
         logger.info(
             "SSH session (Version: %s) from %s:%i to %s:%i began",
-            ssh_version, self.src_address, self.src_port,
+            self.ssh_version, self.src_address, self.src_port,
             self.dst_address, self.dst_port)
 
     def log_pty_request(self, term: str,

--- a/frontend/frontend/honeylogger/_console.py
+++ b/frontend/frontend/honeylogger/_console.py
@@ -25,10 +25,10 @@ class ConsoleLogSSHSession():
         self.dst_address = str(dst_address)
         self.dst_port = dst_port
 
-    def begin(self) -> None:
+    def begin(self, ssh_version: str) -> None:
         logger.info(
-            "SSH session from %s:%i to %s:%i began",
-            self.src_address, self.src_port,
+            "SSH session (Version: %s) from %s:%i to %s:%i began",
+            ssh_version, self.src_address, self.src_port,
             self.dst_address, self.dst_port)
 
     def log_pty_request(self, term: str,

--- a/frontend/frontend/honeylogger/_console.py
+++ b/frontend/frontend/honeylogger/_console.py
@@ -39,6 +39,28 @@ class ConsoleLogSSHSession():
                     term_width_cols, term_height_rows,
                     term_width_pixels, term_height_pixels)
 
+    def log_env_request(self, chan_id: int, name: str, value: str) -> None:
+        logger.info("[%s] SSH ENV request on channel %s: name: %s, value: %s",
+                    self.source, chan_id, name, value)
+
+    def log_direct_tcpip_request(
+            self, chan_id: int, origin_ip: IPAddress, origin_port: int,
+            destination: str, destination_port: int) -> None:
+        logger.info(
+            "[%s] SSH Direct TCPIP request on channel %s: origin_ip: %s, origin_port: %s, destination: %s destination_port: %s",
+            self.source, chan_id, origin_ip, origin_port, destination, destination_port)
+
+    def log_x11_request(
+            self, chan_id: int, single_connection: bool, auth_protocol: str,
+            auth_cookie: memoryview, screen_number: int) -> None:
+        logger.info(
+            "[%s] SSH X11 request on channel %s: single_connection: %s, auth_protocol: %s, auth_cookie: %s screen_number: %s",
+            self.source, chan_id, single_connection, auth_protocol, auth_cookie, screen_number)
+
+    def log_port_forward_request(self, address: str, port: int) -> None:
+        logger.info("[%s] SSH port forward request: address: %s, port: %s",
+                    self.source, address, port)
+
     def log_login_attempt(self, username: str, password: str) -> None:
         logger.info("[%s] Login attempt: %s/%s",
                     self.source, username, password)
@@ -48,7 +70,6 @@ class ConsoleLogSSHSession():
                     self.source, input)
 
     def log_ssh_channel_output(self, data: memoryview, channel: int) -> None:
-        return
         logger.info("[%s] Output recieved on channel %d",
                     self.source, channel)
 

--- a/frontend/frontend/honeylogger/_console.py
+++ b/frontend/frontend/honeylogger/_console.py
@@ -47,18 +47,18 @@ class ConsoleLogSSHSession():
             self, chan_id: int, origin_ip: IPAddress, origin_port: int,
             destination: str, destination_port: int) -> None:
         logger.info(
-            "[%s] SSH Direct TCPIP request on channel %s: origin_ip: %s, origin_port: %s, destination: %s destination_port: %s",
+            "[%s] SSH Direct TCPIP request on channel %d: origin_ip: %s, origin_port: %d, destination: %s destination_port: %d",
             self.source, chan_id, origin_ip, origin_port, destination, destination_port)
 
     def log_x11_request(
             self, chan_id: int, single_connection: bool, auth_protocol: str,
             auth_cookie: memoryview, screen_number: int) -> None:
         logger.info(
-            "[%s] SSH X11 request on channel %s: single_connection: %s, auth_protocol: %s, auth_cookie: %s screen_number: %s",
+            "[%s] SSH X11 request on channel %d: single_connection: %s, auth_protocol: %s, auth_cookie: %s screen_number: %d",
             self.source, chan_id, single_connection, auth_protocol, auth_cookie, screen_number)
 
     def log_port_forward_request(self, address: str, port: int) -> None:
-        logger.info("[%s] SSH port forward request: address: %s, port: %s",
+        logger.info("[%s] SSH port forward request: address: %s, port: %d",
                     self.source, address, port)
 
     def log_login_attempt(self, username: str, password: str) -> None:

--- a/frontend/frontend/honeylogger/_postgres.py
+++ b/frontend/frontend/honeylogger/_postgres.py
@@ -71,6 +71,82 @@ class PostgresLogSSHSession:
         finally:
             conn.close()
 
+    def log_env_request(self, chan_id: int, name: str, value: str) -> None:
+        if self.session_id is None:
+            raise ValueError('Logging session has not been started')
+
+        conn = db.connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    event_id = insert_new_event(
+                        cur, self.session_id, 'env_request')
+                    cur.execute("""
+                        INSERT INTO EnvRequest (event_id, event_type, session_protocol, channel_id,
+                            name, value)
+                            VALUES (%s, 'env_request', 'ssh', %s, %s, %s)
+                        """, (event_id, chan_id, name, value))
+        finally:
+            conn.close()
+
+    def log_direct_tcpip_request(
+            self, chan_id: int, origin_ip: IPAddress, origin_port: int,
+            destination: str, destination_port: int) -> None:
+        if self.session_id is None:
+            raise ValueError('Logging session has not been started')
+
+        conn = db.connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    event_id = insert_new_event(
+                        cur, self.session_id, 'direct_tcpip_request')
+                    cur.execute("""
+                        INSERT INTO DirectTCPIPRequest (event_id, event_type, session_protocol, channel_id,
+                            origin_ip, origin_port, destination, destination_port)
+                            VALUES (%s, 'direct_tcpip_request', 'ssh', %s, %s, %s, %s, %s)
+                        """, (event_id, chan_id, str(origin_ip), origin_port, destination, destination_port))
+        finally:
+            conn.close()
+
+    def log_x11_request(
+            self, chan_id: int, single_connection: bool, auth_protocol: str,
+            auth_cookie: memoryview, screen_number: int) -> None:
+        if self.session_id is None:
+            raise ValueError('Logging session has not been started')
+
+        conn = db.connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    event_id = insert_new_event(
+                        cur, self.session_id, 'x_eleven_request')
+                    cur.execute("""
+                        INSERT INTO XElevenRequest (event_id, event_type, session_protocol, channel_id,
+                            single_connection, auth_protocol, auth_cookie, screen_number)
+                            VALUES (%s, 'x_eleven_request', 'ssh', %s, %s, %s, %s, %s)
+                        """, (event_id, chan_id, single_connection, auth_protocol, auth_cookie, screen_number))
+        finally:
+            conn.close()
+
+    def log_port_forward_request(self, address: str, port: int) -> None:
+        if self.session_id is None:
+            raise ValueError('Logging session has not been started')
+
+        conn = db.connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    event_id = insert_new_event(
+                        cur, self.session_id, 'port_forward_request')
+                    cur.execute("""
+                        INSERT INTO PortForwardRequest (event_id, event_type, session_protocol,
+                            address, port)
+                            VALUES (%s, 'port_forward_request', 'ssh', %s, %s)
+                        """, (event_id, address, port))
+        finally:
+            conn.close()
+
     def log_pty_request(self, term: str,
                         term_width_cols: int, term_height_rows: int,
                         term_width_pixels: int, term_height_pixels: int) -> None:

--- a/frontend/frontend/honeylogger/_postgres.py
+++ b/frontend/frontend/honeylogger/_postgres.py
@@ -52,7 +52,7 @@ class PostgresLogSSHSession:
         self.dst_address = dst_address
         self.dst_port = dst_port
 
-    def begin(self) -> None:
+    def begin(self, ssh_version: str) -> None:
         if self.session_id is not None:
             raise ValueError('Logging session was already started')
 
@@ -62,10 +62,10 @@ class PostgresLogSSHSession:
                 with conn.cursor() as cur:
                     insert_network_source(cur, self.src_address)
                     cur.execute("""
-                        INSERT INTO Session (attack_src, protocol, src_port, dst_ip, dst_port)
-                            VALUES (%s, 'ssh', %s, %s, %s)
+                        INSERT INTO Session (ssh_version, attack_src, protocol, src_port, dst_ip, dst_port)
+                            VALUES (%s, %s, 'ssh', %s, %s, %s)
                             RETURNING id
-                        """, (str(self.src_address), self.src_port, str(self.dst_address), self.dst_port))
+                        """,  (ssh_version, str(self.src_address), self.src_port, str(self.dst_address), self.dst_port))
 
                     self.session_id = cur.fetchone()[0]
         finally:

--- a/frontend/frontend/protocols/ssh/_ssh_server.py
+++ b/frontend/frontend/protocols/ssh/_ssh_server.py
@@ -56,7 +56,8 @@ class Server(paramiko.ServerInterface):
         # Make sure to start the logging session if it isn't started
         if not self._logging_session_started:
             try:
-                self._session.begin(self._transport.remote_version)
+                self._session.set_remote_version(self._transport.remote_version)
+                self._session.begin()
                 self._logging_session_started = True
             except Exception as exc:
                 logger.exception("Failed to start the SSH logging session", exc_info=exc)

--- a/frontend/frontend/protocols/ssh/_ssh_server.py
+++ b/frontend/frontend/protocols/ssh/_ssh_server.py
@@ -1,4 +1,4 @@
-from ipaddress import AddressValueError, IPv4Address
+from ipaddress import AddressValueError,  ip_address
 import logging
 import datetime
 from typing import List, Optional, Set, Tuple
@@ -144,7 +144,7 @@ class Server(paramiko.ServerInterface):
             destination: Tuple[str, int]) -> int:
         self._update_last_activity()
         try:
-            ip = IPv4Address(origin[0])
+            ip = ip_address(origin[0])
         except AddressValueError:
             logger.error("Failed to decode the origin IP %s into an IPv4 address", origin[0])
             return OPEN_FAILED_CONNECT_FAILED

--- a/frontend/frontend/protocols/ssh/_ssh_server.py
+++ b/frontend/frontend/protocols/ssh/_ssh_server.py
@@ -126,9 +126,17 @@ class Server(paramiko.ServerInterface):
         return self._proxy_handler.handle_window_change_request(
             channel, width, height, pixelwidth, pixelheight)
 
-    def check_channel_env_request(self, channel: Channel, name: str, value: str) -> bool:
+    def check_channel_env_request(self, channel: Channel, name: bytes, value: bytes) -> bool:
         self._update_last_activity()
-        self._session.log_env_request(channel.chanid, name, value)
+        try:
+            name_string = name.decode("utf-8")
+            value_string = value.decode("utf-8")
+        except UnicodeDecodeError:
+            logger.error("Failed to decode the env requset  with name: %s and value: %s",
+                         name, value)
+            return False
+
+        self._session.log_env_request(channel.chanid, name_string, value_string)
         return False
 
     def check_channel_direct_tcpip_request(

--- a/frontend/frontend/protocols/ssh/_ssh_server.py
+++ b/frontend/frontend/protocols/ssh/_ssh_server.py
@@ -145,7 +145,7 @@ class Server(paramiko.ServerInterface):
         self._update_last_activity()
         try:
             ip = ip_address(origin[0])
-        except AddressValueError:
+        except ValueError:
             logger.error("Failed to decode the origin IP %s into an IPv4 address", origin[0])
             return OPEN_FAILED_CONNECT_FAILED
         self._session.log_direct_tcpip_request(

--- a/frontend/frontend/protocols/ssh/connection_manager.py
+++ b/frontend/frontend/protocols/ssh/connection_manager.py
@@ -112,7 +112,7 @@ class ConnectionManager(threading.Thread):
 
             proxy_handler = ProxyHandler(session)
             transport.add_server_key(self._host_key)
-            server = Server(session, proxy_handler, self._usernames, self._passwords)
+            server = Server(transport, session,  proxy_handler, self._usernames, self._passwords)
             try:
                 transport.start_server(server=server)
             except SSHException:
@@ -123,7 +123,6 @@ class ConnectionManager(threading.Thread):
             except Exception:
                 logger.exception("Failed to start the SSH server for %s", addr[0])
                 continue
-            logger.info("Remote SSH version %s", transport.remote_version)
 
             transport_manager.add_transport(TransportPair(transport, proxy_handler, server))
 

--- a/frontend/tests/logging/test_postgres.py
+++ b/frontend/tests/logging/test_postgres.py
@@ -1,5 +1,5 @@
 from frontend.honeylogger import create_ssh_session
-from ipaddress import ip_address
+from ipaddress import IPv4Address, ip_address
 
 
 def test_no_runtime_errors():
@@ -20,5 +20,11 @@ def test_no_runtime_errors():
     session.log_ssh_channel_output(memoryview(b'more output of ls\n'), 1)
     session.log_ssh_channel_output(memoryview(b'SOME COMMAND ONE SECOND CHANNEL\n'), 2)
     session.log_ssh_channel_output(memoryview(b'output on second channel\n'), 2)
+    session.log_env_request(1, "TERM", "screen")
+    session.log_env_request(1523, "tnsrieotena", "pfeiabpu")
+    session.log_direct_tcpip_request(4, IPv4Address("23.4.42.53"), 80, "google.com", 80)
+    session.log_x11_request(4, False, "idk", memoryview(b"43"), 1)
+    session.log_x11_request(5, True, "idkatall", memoryview(b"434"), 1)
+    session.log_port_forward_request("54.123.64.3", 80)
 
     session.end()

--- a/frontend/tests/logging/test_postgres.py
+++ b/frontend/tests/logging/test_postgres.py
@@ -7,7 +7,8 @@ def test_no_runtime_errors():
                                  src_port=3463,
                                  dst_address=ip_address('226.64.12.2'),
                                  dst_port=22)
-    session.begin("SSH-2.0-OpenSSH_fake")
+    session.set_remote_version("SSH-2.0-OpenSSH_fake")
+    session.begin()
 
     session.log_login_attempt('a_username', 'some_password')
     session.log_command('sudo rm -rf /')

--- a/frontend/tests/logging/test_postgres.py
+++ b/frontend/tests/logging/test_postgres.py
@@ -1,5 +1,5 @@
 from frontend.honeylogger import create_ssh_session
-from ipaddress import IPv4Address, ip_address
+from ipaddress import ip_address
 
 
 def test_no_runtime_errors():

--- a/frontend/tests/logging/test_postgres.py
+++ b/frontend/tests/logging/test_postgres.py
@@ -22,7 +22,7 @@ def test_no_runtime_errors():
     session.log_ssh_channel_output(memoryview(b'output on second channel\n'), 2)
     session.log_env_request(1, "TERM", "screen")
     session.log_env_request(1523, "tnsrieotena", "pfeiabpu")
-    session.log_direct_tcpip_request(4, IPv4Address("23.4.42.53"), 80, "google.com", 80)
+    session.log_direct_tcpip_request(4, ip_address("23.4.42.53"), 80, "google.com", 80)
     session.log_x11_request(4, False, "idk", memoryview(b"43"), 1)
     session.log_x11_request(5, True, "idkatall", memoryview(b"434"), 1)
     session.log_port_forward_request("54.123.64.3", 80)

--- a/frontend/tests/logging/test_postgres.py
+++ b/frontend/tests/logging/test_postgres.py
@@ -7,7 +7,7 @@ def test_no_runtime_errors():
                                  src_port=3463,
                                  dst_address=ip_address('226.64.12.2'),
                                  dst_port=22)
-    session.begin()
+    session.begin("SSH-2.0-OpenSSH_fake")
 
     session.log_login_attempt('a_username', 'some_password')
     session.log_command('sudo rm -rf /')

--- a/frontend/tests/protocols/ssh/test_ssh_server.py
+++ b/frontend/tests/protocols/ssh/test_ssh_server.py
@@ -35,7 +35,9 @@ def proxy_handler(logger) -> ProxyHandler:
 
 @pytest.fixture()
 def ssh_server(logger, proxy_handler) -> Server:
-    return Server(logger, proxy_handler, [""], [""])
+    transport_mock = MagicMock()
+    transport_mock.remote_version = "ExampleVersion"
+    return Server(transport_mock, logger, proxy_handler, [""], [""])
 
 
 def test_update_last_activity_without_started_session(ssh_server: Server, logger: SSHSession):


### PR DESCRIPTION
Added logging for

- Associating an SSH session with a SSH version
- [Env requests](https://tools.ietf.org/html/rfc4254#section-6.4)
- [Direct TCPIP requests](https://tools.ietf.org/html/rfc4254#section-7.2)
- [X11 forwarding requests](https://tools.ietf.org/html/rfc4254#section-6.3.1)
- [Port forwarding requests](https://tools.ietf.org/html/rfc4254#section-7.1)

There was another event "agent forwarding" mentioned in #57 but I could not figure out what it corresponded to in the RFC and the event does not carry any data other than the channel (method `check_channel_forward_agent_request` in `_ssh_server.py`), so I didn't add it. I could include it as well if people want
