### PR TITLE
Fix shell delay on unix

### DIFF
--- a/frontend/frontend/protocols/ssh/_proxy_handler.py
+++ b/frontend/frontend/protocols/ssh/_proxy_handler.py
@@ -5,7 +5,7 @@ all the data recieved from the backend during the sesison.
 import logging
 import socket
 import threading
-from time import sleep
+from time import sleep, time
 import select
 import os
 from typing import Optional

--- a/frontend/tests/protocols/ssh/test_proxy_handler.py
+++ b/frontend/tests/protocols/ssh/test_proxy_handler.py
@@ -3,7 +3,9 @@
 import logging
 import threading
 import socket
+import select
 from ipaddress import ip_address
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -196,137 +198,142 @@ def test_close_connection_not_active(logger):
 
 
 def test_proxy_eof_received(logger):
-    debug_log.error = MagicMock()
-    debug_log.exception = MagicMock()
+    with patch("os.name", return_value="nt"):
+        debug_log.error = MagicMock()
+        debug_log.exception = MagicMock()
 
-    attacker_channel = MagicMock()
-    backend_channel = MagicMock()
+        attacker_channel = MagicMock()
+        backend_channel = MagicMock()
 
-    # Mock stuff
-    attacker_channel.eof_received = True
-    attacker_channel.close = MagicMock()
-    backend_channel.eof_received = True
-    backend_channel.close = MagicMock()
+        # Mock stuff
+        attacker_channel.eof_received = True
+        attacker_channel.close = MagicMock()
+        backend_channel.eof_received = True
+        backend_channel.close = MagicMock()
 
-    handle_thread = threading.Thread(
-        target=proxy_data, args=(attacker_channel, backend_channel, logger))
-    handle_thread.start()
+        handle_thread = threading.Thread(
+            target=proxy_data, args=(attacker_channel, backend_channel, logger))
+        handle_thread.start()
 
-    handle_thread.join(1)
+        handle_thread.join(1)
 
-    # Both should be closed since both has sent eof
-    attacker_channel.close.assert_called_once()
-    backend_channel.close.assert_called_once()
-    debug_log.exception.assert_not_called()
-    debug_log.error.assert_not_called()
+        # Both should be closed since both has sent eof
+        attacker_channel.close.assert_called_once()
+        backend_channel.close.assert_called_once()
+        debug_log.exception.assert_not_called()
+        debug_log.error.assert_not_called()
 
 
 def test_open_channel_send_exit_code(logger):
-    debug_log.error = MagicMock()
-    debug_log.exception = MagicMock()
+    with patch("os.name", return_value="nt"):
+        debug_log.error = MagicMock()
+        debug_log.exception = MagicMock()
 
-    attacker_channel = MagicMock()
-    backend_channel = MagicMock()
+        attacker_channel = MagicMock()
+        backend_channel = MagicMock()
 
-    # Mock stuff
-    attacker_channel.close = MagicMock()
-    attacker_channel.eof_received = False
-    attacker_channel.closed = False
-    attacker_channel.send_exit_status = MagicMock()
+        # Mock stuff
+        attacker_channel.close = MagicMock()
+        attacker_channel.eof_received = False
+        attacker_channel.closed = False
+        attacker_channel.send_exit_status = MagicMock()
 
-    backend_channel.close = MagicMock()
-    backend_channel.eof_received = True
-    backend_channel.recv_ready = MagicMock(return_value=False)
-    backend_channel.recv_stderr_ready = MagicMock(return_value=False)
-    backend_channel.exit_status_ready = MagicMock(return_value=True)
-    backend_channel.recv_exit_status = MagicMock(return_value=1337)
+        backend_channel.close = MagicMock()
+        backend_channel.eof_received = True
+        backend_channel.recv_ready = MagicMock(return_value=False)
+        backend_channel.recv_stderr_ready = MagicMock(return_value=False)
+        backend_channel.exit_status_ready = MagicMock(return_value=True)
+        backend_channel.recv_exit_status = MagicMock(return_value=1337)
 
-    handle_thread = threading.Thread(
-        target=proxy_data, args=(attacker_channel, backend_channel, logger))
-    handle_thread.start()
+        handle_thread = threading.Thread(
+            target=proxy_data, args=(attacker_channel, backend_channel, logger))
+        handle_thread.start()
 
-    handle_thread.join(1)
+        handle_thread.join(1)
 
-    attacker_channel.close.assert_called_once()
-    backend_channel.close.assert_not_called()
-    attacker_channel.send_exit_status.assert_called_once_with(1337)
+        attacker_channel.close.assert_called_once()
+        backend_channel.close.assert_not_called()
+        attacker_channel.send_exit_status.assert_called_once_with(1337)
 
-    debug_log.exception.assert_not_called()
-    debug_log.error.assert_not_called()
+        debug_log.exception.assert_not_called()
+        debug_log.error.assert_not_called()
 
 
 def test_proxy_to_backend(logger):
-    debug_log.error = MagicMock()
-    debug_log.exception = MagicMock()
-    logger.log_ssh_channel_output = MagicMock()
+    with patch("os.name", return_value="nt"):
+        debug_log.error = MagicMock()
+        debug_log.exception = MagicMock()
+        logger.log_ssh_channel_output = MagicMock()
 
-    attacker_channel = MagicMock()
-    backend_channel = MagicMock()
-    data = b"432153425"
+        attacker_channel = MagicMock()
+        backend_channel = MagicMock()
+        data = b"432153425"
 
-    # Mock stuff
-    attacker_channel.close = MagicMock()
-    attacker_channel.recv_ready = MagicMock(side_effect=[True, False])
-    attacker_channel.recv = MagicMock(return_value=data)
-    attacker_channel.eof_received = False
-    attacker_channel.closed = False
+        # Mock stuff
+        attacker_channel.close = MagicMock()
+        attacker_channel.recv_ready = MagicMock(side_effect=[True, False])
+        attacker_channel.recv = MagicMock(return_value=data)
+        attacker_channel.eof_received = False
+        attacker_channel.closed = False
 
-    backend_channel.close = MagicMock()
-    backend_channel.sendall = MagicMock()
-    backend_channel.eof_received = False
-    backend_channel.closed = False
+        backend_channel.close = MagicMock()
+        backend_channel.sendall = MagicMock()
+        backend_channel.eof_received = False
+        backend_channel.closed = False
 
-    backend_channel.recv_ready = MagicMock(return_value=False)
-    backend_channel.recv_stderr_ready = MagicMock(return_value=False)
-    backend_channel.exit_status_ready = MagicMock(return_value=True)
+        backend_channel.recv_ready = MagicMock(return_value=False)
+        backend_channel.recv_stderr_ready = MagicMock(return_value=False)
+        backend_channel.exit_status_ready = MagicMock(return_value=True)
 
-    handle_thread = threading.Thread(
-        target=proxy_data, args=(attacker_channel, backend_channel, logger))
-    handle_thread.start()
+        handle_thread = threading.Thread(
+            target=proxy_data, args=(attacker_channel, backend_channel, logger))
+        handle_thread.start()
 
-    # Simulate closing the attacker channel so the thread doesn't go on forever
-    attacker_channel.eof_received = True
+        # Simulate closing the attacker channel so the thread doesn't go on forever
+        attacker_channel.eof_received = True
 
-    handle_thread.join(2)
+        handle_thread.join(2)
 
-    backend_channel.close.assert_called_once()
-    backend_channel.sendall.assert_called_once_with(data)
+        backend_channel.close.assert_called_once()
+        backend_channel.sendall.assert_called_once_with(data)
 
-    debug_log.exception.assert_not_called()
-    debug_log.error.assert_not_called()
+        debug_log.exception.assert_not_called()
+        debug_log.error.assert_not_called()
 
 
 def test_proxy_to_attacker(logger):
-    debug_log.error = MagicMock()
-    debug_log.exception = MagicMock()
-    logger.log_ssh_channel_output = MagicMock()
+    with patch("os.name", return_value="nt"):
+        debug_log.error = MagicMock()
+        debug_log.exception = MagicMock()
+        logger.log_ssh_channel_output = MagicMock()
 
-    backend_channel = MagicMock()
-    attacker_channel = MagicMock()
-    data = b"432153425"
+        backend_channel = MagicMock()
+        attacker_channel = MagicMock()
+        data = b"432153425"
 
-    # Mock stuff
-    attacker_channel.eof_received = False
-    attacker_channel.closed = False
-    attacker_channel.close = MagicMock()
-    attacker_channel.sendall = MagicMock()
+        # Mock stuff
+        attacker_channel.eof_received = False
+        attacker_channel.closed = False
+        attacker_channel.close = MagicMock()
+        attacker_channel.sendall = MagicMock()
 
-    backend_channel.close = MagicMock()
-    backend_channel.eof_received = True
-    backend_channel.closed = True
+        backend_channel.close = MagicMock()
+        backend_channel.eof_received = True
+        backend_channel.closed = True
 
-    backend_channel.recv_ready = MagicMock(side_effect=[True, True, False])
-    backend_channel.recv = MagicMock(return_value=data)
-    backend_channel.recv_stderr_ready = MagicMock(return_value=False)
+        backend_channel.recv_ready = MagicMock(
+            side_effect=[True, True, False, False, False, False, False, False])
+        backend_channel.recv = MagicMock(return_value=data)
+        backend_channel.recv_stderr_ready = MagicMock(return_value=False)
 
-    handle_thread = threading.Thread(
-        target=proxy_data, args=(attacker_channel, backend_channel, logger))
-    handle_thread.start()
+        handle_thread = threading.Thread(
+            target=proxy_data, args=(attacker_channel, backend_channel, logger))
+        handle_thread.start()
 
-    handle_thread.join(2)
+        handle_thread.join(2)
 
-    attacker_channel.close.assert_called_once()
-    attacker_channel.sendall.assert_called_once_with(data)
+        attacker_channel.close.assert_called_once()
+        attacker_channel.sendall.assert_called_once_with(data)
 
-    debug_log.error.assert_not_called()
-    debug_log.exception.assert_not_called()
+        debug_log.error.assert_not_called()
+        debug_log.exception.assert_not_called()


### PR DESCRIPTION
It'll now go through the loop every time data arrives on the channels or once every 500ms (posix systems).
Windows will still have a 100ms delay on each loop