### PR TITLE
Fix root@ip login

### DIFF
--- a/backend/custom-cont-init.d/init.sh
+++ b/backend/custom-cont-init.d/init.sh
@@ -56,6 +56,10 @@ chmod -R 777 /home/$USER_NAME/
 
 # Update home directory path in passwd file 
 sed -i "s/\/config/\/home\/$USER_NAME/" "/etc/passwd" 
+
+# Allow @root login
+sed -i "s/#PermitRootLogin prohibit-password/PermitRootLogin yes/g" "/etc/ssh/sshd_config"
+
 # Remove setup files
 rm -rf /docker-mods
 


### PR DESCRIPTION
Changed the sshd_config file to permit root login, not sure if it has any security issues, but it fixes the problem. You can now login with root@ip.