### PR TITLE
Improve database connection and insert performance and insert session atomically

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -51,6 +51,9 @@ services:
       dev:
         aliases:
           - frontend
+    depends_on:
+      - postgres
+      - backend
     restart: always
 
   # Backend

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - SSH_SOCKET_TIMEOUT=5
       - SSH_MAX_UNACCEPTED_CONNECTIONS=100 # Max number of unacceped connections for the SSH socket
       - ENABLE_DEBUG_LOGGING=False
-      - SSH_LOG_FILE=./frontend/honeypot.log # Log file to log to
+      - LOG_FILE=./frontend/honeypot.log # Log file to log to
       - BACKEND_ADDRESS=backend:80
     volumes:
       - "../frontend/frontend:/usr/src/frontend/frontend"

--- a/frontend/config/database.ini
+++ b/frontend/config/database.ini
@@ -3,3 +3,5 @@ host=database
 database=honeypot_db
 user=user
 password=password
+min_connections=1
+max_connections=50

--- a/frontend/docker-compose.yaml
+++ b/frontend/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - SSH_SOCKET_TIMEOUT=5
       - SSH_MAX_UNACCEPTED_CONNECTIONS=100 # Max number of unacceped connections for the SSH socket
       - ENABLE_DEBUG_LOGGING=False
-      - SSH_LOG_FILE=./frontend/honeypot.log # Log file to log to
+      - LOG_FILE=./frontend/honeypot.log # Log file to log to
       - BACKEND_ADDRESS # Address to backend
     volumes:
       - "./frontend:/usr/src/frontend/frontend"

--- a/frontend/frontend/__main__.py
+++ b/frontend/frontend/__main__.py
@@ -6,7 +6,7 @@ import coloredlogs
 import paramiko
 from frontend.protocols.ssh import ConnectionManager as SSHConnectionManager
 from frontend.config import config
-import frontend.protocols.ssh
+import frontend
 from frontend.target_systems import create_grpc_target_system_provider
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ def setup_logging():
     file_formatter = logging.Formatter(
         fmt='%(asctime)s %(levelname)-8s %(message)s (%(threadName)s, %(name)s)',
         datefmt='%Y-%m-%d %H:%M:%S')
-    file_handler = logging.FileHandler(config.SSH_LOG_FILE, encoding='UTF-8')
+    file_handler = logging.FileHandler(config.LOG_FILE, encoding='UTF-8')
     file_handler.setFormatter(file_formatter)
     root_logger.addHandler(file_handler)
 
@@ -44,8 +44,8 @@ def setup_logging():
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)
 
-    if config.SSH_ENABLE_DEBUG_LOGGING:
-        ssh_logger = logging.getLogger(frontend.protocols.ssh.__name__)
+    if config.ENABLE_DEBUG_LOGGING:
+        ssh_logger = logging.getLogger(frontend.__name__)
         ssh_logger.setLevel(logging.DEBUG)
 
 

--- a/frontend/frontend/config/config.py
+++ b/frontend/frontend/config/config.py
@@ -29,10 +29,10 @@ SSH_SOCKET_TIMEOUT = float(os.getenv('SSH_SOCKET_TIMEOUT', '5'))
 SSH_MAX_UNACCEPTED_CONNECTIONS = int(os.getenv('SSH_MAX_UNACCEPTED_CONNECTIONS', '100'))
 
 # Debug logging
-SSH_ENABLE_DEBUG_LOGGING = os.getenv('ENABLE_DEBUG_LOGGING', 'False') == 'True'
+ENABLE_DEBUG_LOGGING = os.getenv('ENABLE_DEBUG_LOGGING', 'False') == 'True'
 
-# Log file for SSH if debug logging is enabled
-SSH_LOG_FILE = os.getenv('SSH_LOG_FILE', './honeypot.log')
+# Log file
+LOG_FILE = os.getenv('LOG_FILE', './honeypot.log')
 
 # The address to a host running a server supporting the target_system_provider gRCP protocol
 # Example: localhost:80

--- a/frontend/frontend/database/__init__.py
+++ b/frontend/frontend/database/__init__.py
@@ -1,1 +1,1 @@
-from .connect import connect
+from .connect import connect, create_pool

--- a/frontend/frontend/database/connect.py
+++ b/frontend/frontend/database/connect.py
@@ -1,21 +1,45 @@
 import logging
 import psycopg2
+from psycopg2 import pool
 from frontend.database.config import config
 
 logger = logging.getLogger(__name__)
 
+db_config = config()
+
 
 def connect():
-    """ Connects to the PostgreSQL database server """
-    try:
-        # read connection parameters
-        params = config()
+    """Connects to the PostgreSQL database server
 
-        # connect to the PostgreSQL server
+    :return: The psycopg2 ``connection`` object for the connection. 
+    """
+    try:
+        # Connect to the PostgreSQL server
         logger.debug('Connecting to the PostgreSQL database...')
-        conn = psycopg2.connect(**params)
+        conn = psycopg2.connect(
+            host=db_config['host'],
+            database=db_config['database'],
+            user=db_config['user'],
+            password=db_config['password']
+        )
 
         return conn
-    except (Exception, psycopg2.DatabaseError):
+    except Exception:
         logger.exception('Failed to connect to Postgres database')
         raise
+
+
+def create_pool() -> pool.ThreadedConnectionPool:
+    """Creates a new pool of database connections.
+
+    :return: The connection pool.
+    """
+
+    return pool.ThreadedConnectionPool(
+        minconn=db_config['min_connections'],
+        maxconn=db_config['max_connections'],
+        host=db_config['host'],
+        database=db_config['database'],
+        user=db_config['user'],
+        password=db_config['password']
+    )

--- a/frontend/frontend/honeylogger/__init__.py
+++ b/frontend/frontend/honeylogger/__init__.py
@@ -16,9 +16,14 @@ from typing import Optional, Protocol
 from abc import abstractmethod
 from ._types import IPAddress
 from ._postgres import PostgresLogSSHSession
+import frontend.database as db
 
 
 __all__ = ['Session', 'SSHSession', 'create_ssh_session']
+
+
+# TODO: This should be not be constructed here, but works for the moment.
+db_conn_pool = db.create_pool()
 
 
 class Session(Protocol):
@@ -164,7 +169,8 @@ def create_ssh_session(src_address: IPAddress, src_port: int,
     :return: An established SSH session.
     """
 
-    session = PostgresLogSSHSession(src_address=src_address,
+    session = PostgresLogSSHSession(db_conn_pool,
+                                    src_address=src_address,
                                     src_port=src_port,
                                     dst_address=dst_address,
                                     dst_port=dst_port)

--- a/frontend/frontend/honeylogger/_postgres.py
+++ b/frontend/frontend/honeylogger/_postgres.py
@@ -1,7 +1,14 @@
-from typing import Optional
+from __future__ import annotations
+from datetime import timezone, datetime
+from typing import Any, Callable, Optional
 import hashlib
+import threading
+import logging
 import frontend.database as db
 from ._types import IPAddress
+
+
+logger = logging.getLogger(__name__)
 
 
 def insert_network_source(cur, ip_address: IPAddress):
@@ -12,12 +19,12 @@ def insert_network_source(cur, ip_address: IPAddress):
                 """, (str(ip_address),))
 
 
-def insert_new_event(cur, session_id: int, event_type: str) -> int:
+def insert_new_event(cur, session_id: int, event_type: str, timestamp: datetime) -> int:
     cur.execute("""
-                INSERT INTO Event (session_id, session_protocol, type)
-                    VALUES (%s, 'ssh', %s)
+                INSERT INTO Event (session_id, session_protocol, type, timestamp)
+                    VALUES (%s, 'ssh', %s, %s)
                     RETURNING id
-                """, (session_id, event_type))
+                """, (session_id, event_type, timestamp))
     return cur.fetchone()[0]
 
 
@@ -36,6 +43,10 @@ class PostgresLogSSHSession:
     """Implementation of honeylogger.SSHSession that
     logs session and actions to a Postgres database"""
 
+    _lock: threading.Lock
+
+    _scheduled_inserts: list[InsertFunc]
+
     session_id: Optional[int]
 
     src_address: IPAddress
@@ -46,178 +57,154 @@ class PostgresLogSSHSession:
     def __init__(self,
                  src_address: IPAddress, src_port: int,
                  dst_address: IPAddress, dst_port: int) -> None:
+        self._lock = threading.Lock()
+        self._scheduled_inserts = []
         self.session_id = None
         self.src_address = src_address
         self.src_port = src_port
         self.dst_address = dst_address
         self.dst_port = dst_port
 
+    def _schedule_insert(self, function: InsertFunc) -> None:
+        with self._lock:
+            self._scheduled_inserts.append(function)
+
+    def _get_timestamp(self) -> datetime:
+        return datetime.now(timezone.utc)
+
     def begin(self, ssh_version: str) -> None:
-        if self.session_id is not None:
-            raise ValueError('Logging session was already started')
+        timestamp = self._get_timestamp()
 
-        conn = db.connect()
-        try:
-            with conn:
-                with conn.cursor() as cur:
-                    insert_network_source(cur, self.src_address)
-                    cur.execute("""
-                        INSERT INTO Session (ssh_version, attack_src, protocol, src_port, dst_ip, dst_port)
-                            VALUES (%s, %s, 'ssh', %s, %s, %s)
-                            RETURNING id
-                        """,  (ssh_version, str(self.src_address), self.src_port, str(self.dst_address), self.dst_port))
+        def insert(cur, session):
+            if session.session_id is not None:
+                raise ValueError('Logging session was already started')
 
-                    self.session_id = cur.fetchone()[0]
-        finally:
-            conn.close()
+            insert_network_source(cur, session.src_address)
+            cur.execute("""
+                INSERT INTO Session (ssh_version, attack_src, protocol, src_port, dst_ip, dst_port, start_timestamp)
+                    VALUES (%s, %s, 'ssh', %s, %s, %s, %s)
+                    RETURNING id
+                """, (ssh_version, str(session.src_address), session.src_port,
+                      str(session.dst_address), session.dst_port, timestamp))
 
-    def log_env_request(self, chan_id: int, name: str, value: str) -> None:
-        if self.session_id is None:
-            raise ValueError('Logging session has not been started')
+            session.session_id = cur.fetchone()[0]
 
-        conn = db.connect()
-        try:
-            with conn:
-                with conn.cursor() as cur:
-                    event_id = insert_new_event(
-                        cur, self.session_id, 'env_request')
-                    cur.execute("""
-                        INSERT INTO EnvRequest (event_id, event_type, session_protocol, channel_id,
-                            name, value)
-                            VALUES (%s, 'env_request', 'ssh', %s, %s, %s)
-                        """, (event_id, chan_id, name, value))
-        finally:
-            conn.close()
-
-    def log_direct_tcpip_request(
-            self, chan_id: int, origin_ip: IPAddress, origin_port: int,
-            destination: str, destination_port: int) -> None:
-        if self.session_id is None:
-            raise ValueError('Logging session has not been started')
-
-        conn = db.connect()
-        try:
-            with conn:
-                with conn.cursor() as cur:
-                    event_id = insert_new_event(
-                        cur, self.session_id, 'direct_tcpip_request')
-                    cur.execute("""
-                        INSERT INTO DirectTCPIPRequest (event_id, event_type, session_protocol, channel_id,
-                            origin_ip, origin_port, destination, destination_port)
-                            VALUES (%s, 'direct_tcpip_request', 'ssh', %s, %s, %s, %s, %s)
-                        """, (event_id, chan_id, str(origin_ip), origin_port, destination, destination_port))
-        finally:
-            conn.close()
-
-    def log_x11_request(
-            self, chan_id: int, single_connection: bool, auth_protocol: str,
-            auth_cookie: memoryview, screen_number: int) -> None:
-        if self.session_id is None:
-            raise ValueError('Logging session has not been started')
-
-        conn = db.connect()
-        try:
-            with conn:
-                with conn.cursor() as cur:
-                    event_id = insert_new_event(
-                        cur, self.session_id, 'x_eleven_request')
-                    cur.execute("""
-                        INSERT INTO XElevenRequest (event_id, event_type, session_protocol, channel_id,
-                            single_connection, auth_protocol, auth_cookie, screen_number)
-                            VALUES (%s, 'x_eleven_request', 'ssh', %s, %s, %s, %s, %s)
-                        """, (event_id, chan_id, single_connection, auth_protocol, auth_cookie, screen_number))
-        finally:
-            conn.close()
-
-    def log_port_forward_request(self, address: str, port: int) -> None:
-        if self.session_id is None:
-            raise ValueError('Logging session has not been started')
-
-        conn = db.connect()
-        try:
-            with conn:
-                with conn.cursor() as cur:
-                    event_id = insert_new_event(
-                        cur, self.session_id, 'port_forward_request')
-                    cur.execute("""
-                        INSERT INTO PortForwardRequest (event_id, event_type, session_protocol,
-                            address, port)
-                            VALUES (%s, 'port_forward_request', 'ssh', %s, %s)
-                        """, (event_id, address, port))
-        finally:
-            conn.close()
+        self._schedule_insert(insert)
 
     def log_pty_request(self, term: str,
                         term_width_cols: int, term_height_rows: int,
                         term_width_pixels: int, term_height_pixels: int) -> None:
-        if self.session_id is None:
-            raise ValueError('Logging session has not been started')
+        timestamp = self._get_timestamp()
 
-        conn = db.connect()
-        try:
-            with conn:
-                with conn.cursor() as cur:
-                    event_id = insert_new_event(
-                        cur, self.session_id, 'pty_request')
-                    cur.execute("""
-                        INSERT INTO PTYRequest (event_id, event_type, session_protocol, term, term_width_cols,
-                            term_height_rows, term_width_pixels, term_height_pixels)
-                            VALUES (%s, 'pty_request', 'ssh', %s, %s, %s, %s, %s)
-                        """, (event_id, term, term_width_cols,
-                              term_height_rows, term_width_pixels, term_height_pixels))
-        finally:
-            conn.close()
+        def insert(cur, session):
+            event_id = insert_new_event(
+                cur, session.session_id, 'pty_request', timestamp)
+            cur.execute("""
+                INSERT INTO PTYRequest (event_id, event_type, session_protocol, term, term_width_cols,
+                    term_height_rows, term_width_pixels, term_height_pixels)
+                    VALUES (%s, 'pty_request', 'ssh', %s, %s, %s, %s, %s)
+                """, (event_id, term, term_width_cols,
+                      term_height_rows, term_width_pixels, term_height_pixels))
+
+        self._schedule_insert(insert)
+
+    def log_env_request(self, chan_id: int, name: str, value: str) -> None:
+        timestamp = self._get_timestamp()
+
+        def insert(cur, session):
+            event_id = insert_new_event(
+                cur, session.session_id, 'env_request', timestamp)
+            cur.execute("""
+                INSERT INTO EnvRequest (event_id, event_type, session_protocol, channel_id,
+                    name, value)
+                    VALUES (%s, 'env_request', 'ssh', %s, %s, %s)
+                """, (event_id, chan_id, name, value))
+
+        self._schedule_insert(insert)
+
+    def log_direct_tcpip_request(self, chan_id: int, origin_ip: IPAddress, origin_port: int,
+                                 destination: str, destination_port: int) -> None:
+        timestamp = self._get_timestamp()
+
+        def insert(cur, session):
+            event_id = insert_new_event(
+                cur, session.session_id, 'direct_tcpip_request', timestamp)
+            cur.execute("""
+                INSERT INTO DirectTCPIPRequest (event_id, event_type, session_protocol, channel_id,
+                    origin_ip, origin_port, destination, destination_port)
+                    VALUES (%s, 'direct_tcpip_request', 'ssh', %s, %s, %s, %s, %s)
+                """, (event_id, chan_id, str(origin_ip), origin_port, destination, destination_port))
+
+        self._schedule_insert(insert)
+
+    def log_x11_request(
+            self, chan_id: int, single_connection: bool, auth_protocol: str,
+            auth_cookie: memoryview, screen_number: int) -> None:
+        timestamp = self._get_timestamp()
+
+        def insert(cur, session):
+            event_id = insert_new_event(
+                cur, session.session_id, 'x_eleven_request', timestamp)
+            cur.execute("""
+                INSERT INTO XElevenRequest (event_id, event_type, session_protocol, channel_id,
+                    single_connection, auth_protocol, auth_cookie, screen_number)
+                    VALUES (%s, 'x_eleven_request', 'ssh', %s, %s, %s, %s, %s)
+                """, (event_id, chan_id, single_connection, auth_protocol, auth_cookie, screen_number))
+
+        self._schedule_insert(insert)
+
+    def log_port_forward_request(self, address: str, port: int) -> None:
+        timestamp = self._get_timestamp()
+
+        def insert(cur, session):
+            event_id = insert_new_event(
+                cur, session.session_id, 'port_forward_request', timestamp)
+            cur.execute("""
+                INSERT INTO PortForwardRequest (event_id, event_type, session_protocol,
+                    address, port)
+                    VALUES (%s, 'port_forward_request', 'ssh', %s, %s)
+                """, (event_id, address, port))
+
+        self._schedule_insert(insert)
 
     def log_login_attempt(self, username: str, password: str) -> None:
-        if self.session_id is None:
-            raise ValueError('Logging session has not been started')
+        timestamp = self._get_timestamp()
 
-        conn = db.connect()
-        try:
-            with conn:
-                with conn.cursor() as cur:
-                    event_id = insert_new_event(
-                        cur, self.session_id, 'login_attempt')
-                    cur.execute("""
-                        INSERT INTO LoginAttempt (event_id, username, password)
-                            VALUES (%s, %s, %s)
-                        """, (event_id, username, password))
-        finally:
-            conn.close()
+        def insert(cur, session):
+            event_id = insert_new_event(
+                cur, session.session_id, 'login_attempt', timestamp)
+            cur.execute("""
+                INSERT INTO LoginAttempt (event_id, username, password)
+                    VALUES (%s, %s, %s)
+                """, (event_id, username, password))
+
+        self._schedule_insert(insert)
 
     def log_command(self, input: str) -> None:
-        if self.session_id is None:
-            raise ValueError('Logging session has not been started')
+        timestamp = self._get_timestamp()
 
-        conn = db.connect()
-        try:
-            with conn:
-                with conn.cursor() as cur:
-                    event_id = insert_new_event(
-                        cur, self.session_id, 'command')
-                    cur.execute("""
-                        INSERT INTO Command (event_id, input)
-                            VALUES (%s, %s)
-                        """, (event_id, input))
-        finally:
-            conn.close()
+        def insert(cur, session):
+            event_id = insert_new_event(
+                cur, session.session_id, 'command', timestamp)
+            cur.execute("""
+                INSERT INTO Command (event_id, input)
+                    VALUES (%s, %s)
+                """, (event_id, input))
+
+        self._schedule_insert(insert)
 
     def log_ssh_channel_output(self, data: memoryview, channel: int) -> None:
-        if self.session_id is None:
-            raise ValueError('Logging session has not been started')
+        timestamp = self._get_timestamp()
 
-        conn = db.connect()
-        try:
-            with conn:
-                with conn.cursor() as cur:
-                    event_id = insert_new_event(
-                        cur, self.session_id, 'ssh_channel_output')
-                    cur.execute("""
-                        INSERT INTO SSHChannelOutput (event_id, data, channel)
-                            VALUES (%s, %s, %s)
-                        """, (event_id, data, channel))
-        finally:
-            conn.close()
+        def insert(cur, session):
+            event_id = insert_new_event(
+                cur, session.session_id, 'ssh_channel_output', timestamp)
+            cur.execute("""
+                INSERT INTO SSHChannelOutput (event_id, data, channel)
+                    VALUES (%s, %s, %s)
+                """, (event_id, data, channel))
+
+        self._schedule_insert(insert)
 
     def log_download(self,
                      data: memoryview,
@@ -225,36 +212,41 @@ class PostgresLogSSHSession:
                      source_address: IPAddress,
                      source_url: Optional[str] = None,
                      save_data: bool = True) -> None:
-        if self.session_id is None:
-            raise ValueError('Logging session has not been started')
+        timestamp = self._get_timestamp()
 
-        conn = db.connect()
-        try:
-            with conn:
-                with conn.cursor() as cur:
-                    event_id = insert_new_event(
-                        cur, self.session_id, 'download')
-                    file_hash = insert_file(cur, data, file_type, save_data)
-                    insert_network_source(cur, source_address)
-                    cur.execute("""
-                        INSERT INTO Download (event_id, hash, src, url)
-                            VALUES (%s, %s, %s, %s)
-                        """, (event_id, file_hash, str(source_address), source_url))
-        finally:
-            conn.close()
+        def insert(cur, session):
+            event_id = insert_new_event(
+                cur, session.session_id, 'download', timestamp)
+            file_hash = insert_file(cur, data, file_type, save_data)
+            insert_network_source(cur, source_address)
+            cur.execute("""
+                INSERT INTO Download (event_id, hash, src, url)
+                    VALUES (%s, %s, %s, %s)
+                """, (event_id, file_hash, str(source_address), source_url))
+
+        self._schedule_insert(insert)
 
     def end(self) -> None:
-        if self.session_id is None:
-            raise ValueError('Logging session has not been started')
+        timestamp = self._get_timestamp()
 
-        conn = db.connect()
-        try:
-            with conn:
+        def insert(cur, session):
+            cur.execute("""
+                UPDATE Session
+                    SET end_timestamp = %s
+                    WHERE id = %s
+                """, (timestamp, session.session_id))
+
+        self._schedule_insert(insert)
+
+        logger.debug('Inserting logging session into database...')
+        with self._lock:
+            conn = db.connect()
+            with conn:  # Start transaction
                 with conn.cursor() as cur:
-                    cur.execute("""
-                        UPDATE Session
-                            SET end_timestamp = CURRENT_TIMESTAMP
-                            WHERE id = %s
-                        """, (self.session_id,))
-        finally:
-            conn.close()
+                    for func in self._scheduled_inserts:
+                        func(cur, self)
+
+        logger.debug('Logging session inserted')
+
+
+InsertFunc = Callable[[Any, PostgresLogSSHSession], None]

--- a/frontend/frontend/protocols/ssh/_proxy_handler.py
+++ b/frontend/frontend/protocols/ssh/_proxy_handler.py
@@ -185,6 +185,9 @@ class ProxyHandler:
         except Exception as exc:
             logger.exception("Failed to close backend transport", exc_info=exc)
         finally:
+            logger.debug('Yielding %s:%d target system...',
+                         self._connection.target_system.address,
+                         self._connection.target_system.port)
             self._target_system_provider.yield_target_system(self._connection.target_system)
             self._connection = None
 

--- a/frontend/frontend/protocols/ssh/_ssh_server.py
+++ b/frontend/frontend/protocols/ssh/_ssh_server.py
@@ -51,8 +51,9 @@ class Server(paramiko.ServerInterface):
         return self._last_activity
 
     def _update_last_activity(self) -> None:
-        """Updates the last activity seen
-        """
+        """Updates the last activity seen"""
+        self._last_activity = datetime.datetime.now()
+
         # Make sure to start the logging session if it isn't started
         if not self._logging_session_started:
             try:
@@ -61,7 +62,7 @@ class Server(paramiko.ServerInterface):
                 self._logging_session_started = True
             except Exception as exc:
                 logger.exception("Failed to start the SSH logging session", exc_info=exc)
-        self._last_activity = datetime.datetime.now()
+                raise
 
     def check_auth_password(self, username: str, password: str) -> int:
         self._update_last_activity()

--- a/frontend/tests/protocols/ssh/test_ssh_server.py
+++ b/frontend/tests/protocols/ssh/test_ssh_server.py
@@ -62,15 +62,14 @@ def test_update_last_activity_without_started_session(ssh_server: Server, logger
 def test_update_last_activity_exception(ssh_server: Server, logger: SSHSession):
     logger.begin = MagicMock(side_effect=Exception)
 
-    debug_log.exception = MagicMock()
     now = datetime.datetime.now()
 
-    ssh_server._update_last_activity()
+    with pytest.raises(Exception):
+        ssh_server._update_last_activity()
 
     logger.begin.assert_called_once()
     assert ssh_server._logging_session_started == False
     assert time_in_range(now,  datetime.datetime.now(), ssh_server._last_activity)
-    debug_log.exception.assert_called_once()
 
 
 def test_get_last_activity(ssh_server: Server):


### PR DESCRIPTION
Original:
> ~~Database commands for logging in `PostgresLogSSHSession` are now deferred to the end of the logging session where they are all executed in one go in a single transaction.~~
> 
> Running commands with heavy amounts of output should be much smoother.
> 
> Potentials issues:
> - ~~Buffer of deferred commands could demand a lot of RAM. Has not been tested.~~

One connection per session is now used instead of per insert. When the session begins a transaction is opened and when it's ended it is comitted.

Running commands with heavy amounts of output should be much smoother. It should no longer use as much RAM as the previous solution.

Potentials issues:
- Amount of parallel sessions is limited by database connection pool. Currently 100 seems to be the max for Postgres.