### PR TITLE
Network capture

### DIFF
--- a/backend/backend/__main__.py
+++ b/backend/backend/__main__.py
@@ -25,6 +25,9 @@ def main():
         bind_address=config.HTTP_API_BIND_ADDRESS)
     http_server.wait_for_termination()
 
+    # Cleanup remaining containers
+    container_handler.destroy_target_containers()
+
 
 if __name__ == '__main__':
     main()

--- a/backend/backend/config.py
+++ b/backend/backend/config.py
@@ -9,3 +9,9 @@ HTTP_API_BIND_ADDRESS = os.getenv('HTTP_API_BIND_ADDRESS', '0.0.0.0:80')
 
 # The address to use when connecting to acquired target systems
 TARGET_SYSTEM_ADDRESS = os.getenv('TARGET_SYSTEM_ADDRESS')
+
+# If enabled, uses creates a unique Docker network per target container
+# to isolate containers from eachother and reduce amount of redundant
+# captured network traffic.
+ENABLE_ISOLATED_TARGET_CONTAINER_NETWORKS = os.getenv(
+    'ENABLE_ISOLATED_TARGET_CONTAINER_NETWORKS', 'False') == 'True'

--- a/backend/backend/container.py
+++ b/backend/backend/container.py
@@ -1,12 +1,15 @@
 """Contains class and methods used for handling docker containers"""
 
 import io
+import threading
 import tarfile
 import logging
 from enum import Enum
 from typing import cast
 import docker
+from docker.client import DockerClient
 from docker.models.containers import Container
+from docker.models.volumes import Volume
 
 
 logger = logging.getLogger(__name__)
@@ -27,14 +30,35 @@ class Containers:
 
     ID_PREFIX = "openssh-server"
 
+    NETLOG_CONTAINER_SUFFIX = '_netlog'
+    TCPDUMP_IMAGE = 'itsthenetwork/alpine-tcpdump'  # TODO: Might want a custom image
+
+    # Docker API client
+    _client: DockerClient
+
+    # All containers which have successfully been started and not yet destroyed
+    # Must be accessed under lock
+    _containers: set[str]
+    _containers_lock: threading.RLock
+
     def __init__(self):
         self._client = docker.from_env()
         self._client.images.pull('ghcr.io/linuxserver/openssh-server:latest')
+        self._client.images.pull(self.TCPDUMP_IMAGE)
+
+        self._containers = set()
+        self._containers_lock = threading.RLock()
 
     def _get_container(self, container_id: str) -> Container:
+        with self._containers_lock:
+            if container_id not in self._containers:
+                raise ValueError(f'Container with ID {container_id} does not exist')
+            return cast(Container, self._client.containers.get(container_id))
+
+    def _get_container_unchecked(self, container_id: str) -> Container:
         return cast(Container, self._client.containers.get(container_id))
 
-    def create_container(self, config: dict):
+    def create_container(self, config: dict) -> None:
         """Creates a docker container with the specified container_id, exposes the specified SSH port,
            and has SSH login credentials user/password
 
@@ -42,31 +66,65 @@ class Containers:
         containing all environment variables and config needed for setting up a container.
         """
 
-        container = cast(Container, self._client.containers.create(
-            config["Image"],
-            environment=config["Environment"],
-            hostname=config["Hostname"],
-            name=config["ID"],
-            ports=config["Port"],
-            volumes=config["Volumes"]))
+        with self._containers_lock:
+            if config['ID'] in self._containers:
+                raise ValueError(f'Container ID {config["ID"]} is already in use')
+            self._containers.add(config['ID'])
 
-        self.copy_init_to_volume(config["ID"])
-        container.start()
+        container = None
+        netlog_container = None
+        try:
+            container = cast(Container, self._client.containers.create(
+                config["Image"],
+                environment=config["Environment"],
+                hostname=config["Hostname"],
+                name=config["ID"],
+                ports=config["Port"],
+                volumes=config["Volumes"]))
 
-        # reload to get the correct port in config
-        container.reload()
+            self._copy_init_to_volume(config["ID"])
+            container.start()
 
-        logger.info("Started container %s, waiting for it to be ready...", config["ID"])
+            # Start network logging container, has to happen after
+            # starting main container to allow attaching to network
+            netlog_container = self._start_netlog_container(config['ID'])
 
-        # Wait for container SSH-server to be ready
-        while True:
-            exit_code, _ = container.exec_run(
-                '/bin/bash -c "$(s6-svstat -u /run/s6/services/openssh-server) || exit 1"',
-                stdout=False, stderr=False)
-            if exit_code == 0:
-                break
+            logger.info("Started container %s, waiting for it to be ready...", config["ID"])
 
-        logger.info("Container %s ready", config["ID"])
+            # Reload to get the correct port in config
+            container.reload()
+
+            # Wait for target container SSH-server to be ready
+            while True:
+                exit_code, _ = container.exec_run(
+                    '/bin/bash -c "$(s6-svstat -u /run/s6/services/openssh-server) || exit 1"',
+                    stdout=False, stderr=False)
+                if exit_code == 0:
+                    break
+
+            logger.info("Container %s ready", config["ID"])
+        except Exception:
+            with self._containers_lock:
+                self._containers.remove(config['ID'])
+            if container is not None:
+                container.remove(force=True)
+            if netlog_container is not None:
+                netlog_container.remove(force=True)
+            raise
+
+    def _start_netlog_container(self, for_container_id: str) -> Container:
+        netlog_volume = for_container_id + self.NETLOG_CONTAINER_SUFFIX
+        netlog_dir = '/netlog'
+        return cast(Container, self._client.containers.run(
+            self.TCPDUMP_IMAGE,
+            name=for_container_id + self.NETLOG_CONTAINER_SUFFIX,
+            network_mode='container:' + for_container_id,
+            volumes={
+                netlog_volume: {'bind': netlog_dir, 'mode': 'rw'}
+            },
+            command=['-i', 'any', '-w', netlog_dir + '/log.pcap'],
+            detach=True
+        ))
 
     def get_container_port(self, container_id: str) -> int:
         """Returns the port bound to a container. Undefined if multiple ports are used.
@@ -74,23 +132,32 @@ class Containers:
         :param container_id: The container id
         :return: The port bound to container container_id
         """
-        return int(self._client.containers.get(container_id).attrs["NetworkSettings"]["Ports"][
+        return int(self._get_container(container_id).attrs["NetworkSettings"]["Ports"][
             "2222/tcp"][0]["HostPort"])
 
-    def stop_container(self, container_id: str):
+    def stop_container(self, container_id: str) -> None:
         """Stop a specified container
 
         :param container_id: ID (name) of container to be stopped
         """
-        self._get_container(container_id).stop()
+        with self._containers_lock:
+            self._get_container(container_id).stop()
+            self._get_container_unchecked(container_id + self.NETLOG_CONTAINER_SUFFIX).stop()
+
         logger.info("Stopped container %s", container_id)
 
-    def destroy_container(self, container_id: str):
+    def destroy_container(self, container_id: str) -> None:
         """Destroy a specified container
 
         :param container_id: ID (name) of container to be destroyed
         """
-        self._get_container(container_id).remove()
+        with self._containers_lock:
+            container = self._get_container(container_id)
+            self._containers.remove(container_id)
+            container.remove(force=True)
+            self._get_container_unchecked(
+                container_id + self.NETLOG_CONTAINER_SUFFIX).remove(force=True)
+
         logger.info("Destroyed container %s", container_id)
 
     def prune_volumes(self):
@@ -101,13 +168,13 @@ class Containers:
         self._client.volumes.prune()
         logger.info("Pruned all unused volumes")
 
-    def get_volume(self, volume_id: str):
+    def get_volume(self, volume_id: str) -> Volume:
         """Returns the specified volume in form <Volume: short_id>,
         where short_id is the volume id truncated to 10 characters
 
         :param volume_id: The name of the volume
         """
-        return self._client.volumes.get(volume_id)
+        return cast(Volume, self._client.volumes.get(volume_id))
 
     def status_container(self, container_id: str) -> Status:
         """Return the status of a specific container with the container_id argument
@@ -116,8 +183,8 @@ class Containers:
         :return: Returns an enum describing the status of a container
         """
         try:
-            sts = self._client.containers.get(container_id).attrs['State']['Status']
-        except Exception:
+            sts = self._get_container(container_id).attrs['State']['Status']
+        except ValueError:
             return Status.NOTFOUND
         else:
             if sts == "running":
@@ -130,7 +197,15 @@ class Containers:
                 return Status.EXITED
         return Status.UNDEFINED
 
-    def format_config(self, container_id: int, user: str, password: str,
+    def shutdown(self):
+        """Clean up any remaining, previously started, containers."""
+
+        with self._containers_lock:
+            for container_id in self._containers.copy():
+                self.destroy_container(container_id)
+
+    @staticmethod
+    def format_config(container_id: int, user: str, password: str,
                       hostname='Dell-T140', user_id='1000', group_id='1000',
                       timezone='Europe/London', sudo_access='true',
                       image='ghcr.io/linuxserver/openssh-server', port=None) -> dict:
@@ -160,7 +235,7 @@ class Containers:
         config = {
             'Image': image,
             'ID': _container_id,
-            'Environment': self.format_environment(
+            'Environment': Containers._format_environment(
                 user, password, user_id, group_id, timezone, sudo_access
             ),
             'Port': {'2222/tcp': port},
@@ -177,9 +252,11 @@ class Containers:
         }
         return config
 
-    def format_environment(
-            self, user: str, password: str, user_id: str, group_id: str, timezone: str,
-            sudo_access: str) -> list:
+    @staticmethod
+    def _format_environment(user: str, password: str,
+                            user_id: str, group_id: str,
+                            timezone: str,
+                            sudo_access: str) -> list[str]:
         """Formats the given parameters into a list of environment variables used by the container
 
         :param user: Username for container
@@ -190,10 +267,17 @@ class Containers:
         :param sudo_access: Sudo access for container
         :return: List of variables used by the container
         """
-        return ['PUID='+user_id, 'PGID='+group_id, 'TZ='+timezone, 'SUDO_ACCESS='+sudo_access,
-                'PASSWORD_ACCESS=true', 'USER_PASSWORD='+password, 'USER_NAME='+user]
+        return [
+            'PUID=' + user_id,
+            'PGID=' + group_id,
+            'TZ=' + timezone,
+            'SUDO_ACCESS=' + sudo_access,
+            'PASSWORD_ACCESS=true',
+            'USER_PASSWORD=' + password,
+            'USER_NAME=' + user
+        ]
 
-    def copy_init_to_volume(self, container_id: str):
+    def _copy_init_to_volume(self, container_id: str):
         """Copies the init script from
             backend/custom-cont-init.d/ to the container's volume.
 

--- a/backend/backend/http_server.py
+++ b/backend/backend/http_server.py
@@ -51,6 +51,7 @@ class TargetSystemProvider(tsp.TargetSystemProviderServicer):
     def YieldTargetSystem(self, request, context):
         try:
             self.container_handler.stop_container(request.id)
+            # Collect info
             self.container_handler.destroy_container(request.id)
             # TODO: Properly cleanup after information is preserved and sent back to client
             # self.container_handler.prune_volumes()

--- a/backend/backend/http_server.py
+++ b/backend/backend/http_server.py
@@ -6,6 +6,7 @@ Currently handles requests to acquire and yield target systems.
 import logging
 import uuid
 from concurrent import futures
+import threading
 import grpc
 import target_system_provider.target_system_provider_pb2_grpc as tsp
 import target_system_provider.target_system_provider_pb2 as messages
@@ -19,12 +20,20 @@ __all__ = ['start_http_server']
 class TargetSystemProvider(tsp.TargetSystemProviderServicer):
     """Implementation of gRPC TargetSystemProvider service"""
 
-    container_handler: Containers
-    target_system_address: str
+    _container_handler: Containers
+    _target_system_address: str
+
+    # All target systems which have successfully been acquired and not yet yielded
+    # Must be accessed under lock
+    _target_system_ids: set[str]
+    _target_system_ids_lock: threading.Lock
 
     def __init__(self, container_handler: Containers, target_system_address: str):
-        self.container_handler = container_handler
-        self.target_system_address = target_system_address
+        self._container_handler = container_handler
+        self._target_system_address = target_system_address
+
+        self._target_system_ids = set()
+        self._target_system_ids_lock = threading.Lock()
 
     def AcquireTargetSystem(self, request, context):
         container_id = uuid.uuid4().int % (2**32)
@@ -32,8 +41,8 @@ class TargetSystemProvider(tsp.TargetSystemProviderServicer):
         password = request.password
 
         # Start container
-        config = self.container_handler.format_config(container_id, user, password)
-        self.container_handler.create_container(config)
+        config = self._container_handler.format_config(container_id, user, password)
+        self._container_handler.create_container(config)
 
         # TODO:
         # if no target system available:
@@ -41,22 +50,37 @@ class TargetSystemProvider(tsp.TargetSystemProviderServicer):
         #    return messages.AcquisitionResult()
 
         # Get the assigned port, for returning to frontend
-        assigned_port = self.container_handler.get_container_port(config['ID'])
+        assigned_port = self._container_handler.get_container_port(config['ID'])
+
+        # Keep track of which target systems have been acquired
+        with self._target_system_ids_lock:
+            self._target_system_ids.add(config['ID'])
 
         return messages.AcquisitionResult(
             id=config['ID'],
-            address=self.target_system_address,
+            address=self._target_system_address,
             port=assigned_port)
 
     def YieldTargetSystem(self, request, context):
         try:
-            self.container_handler.stop_container(request.id)
-            self.container_handler.destroy_container(request.id)
+            with self._target_system_ids_lock:
+                # May not yield target system which was not
+                # previously acquired from this provider
+                if request.id not in self._target_system_ids:
+                    context.abort(
+                        grpc.StatusCode.NOT_FOUND,
+                        f'Target system with ID {request.id} does not exist')
+                    return messages.YieldResult()
+                self._target_system_ids.remove(request.id)
+
+            self._container_handler.stop_container(request.id)
+            self._container_handler.destroy_container(request.id)
+
             # TODO: Properly cleanup after information is preserved and sent back to client
             # self.container_handler.prune_volumes()
-        except Exception as exception:
+        except Exception:
             logging.exception("Could not find, stop, destroy or cleanup container %s", request.id)
-            raise exception
+            raise
 
         return messages.YieldResult()
 

--- a/backend/backend/io.py
+++ b/backend/backend/io.py
@@ -1,0 +1,39 @@
+"""Module for IO-related utilties"""
+
+import io
+from typing import IO, Iterable, Optional
+
+
+def byte_stream_from_iterable(
+        iterable: Iterable[bytes],
+        buffer_size=io.DEFAULT_BUFFER_SIZE) -> IO[bytes]:
+    """
+    Source: https://gist.github.com/mechanical-snail/7688353
+
+    Lets you use an iterable (e.g. a generator) that yields bytestrings as a read-only input stream.
+
+    The stream implements Python 3's newer I/O API (available in Python 2's io module).
+    For efficiency, the stream is buffered.
+    """
+    iterator = iter(iterable)
+
+    class IterStream(io.RawIOBase):
+        leftover: Optional[bytes]
+
+        def __init__(self):
+            self.leftover = None
+
+        def readable(self):
+            return True
+
+        def readinto(self, b):
+            try:
+                length = len(b)  # We're supposed to return at most this much
+                chunk = self.leftover or next(iterator)
+                output, self.leftover = chunk[:length], chunk[length:]
+                b[:len(output)] = output
+                return len(output)
+            except StopIteration:
+                return 0  # indicate EOF
+
+    return io.BufferedReader(IterStream(), buffer_size=buffer_size)

--- a/backend/tests/test_container.py
+++ b/backend/tests/test_container.py
@@ -1,108 +1,78 @@
-import os
 import pytest
 from backend.container import Containers, Status
 
 MAX_CONTAINERS = 5
 
 
-@pytest.fixture()
+@pytest.fixture
 def config() -> dict:
-    container_handler = Containers()
     container_id = 0
     user = "user"
     password = "password"
+    return Containers.format_config(container_id, user, password)
 
-    return container_handler.format_config(container_id, user, password)
 
-
-@pytest.fixture(autouse=True)
-def run_around_tests():
+@pytest.fixture
+def container_handler():
 
     # Before test
     container_handler = Containers()
 
     # Run test
-    yield
+    yield container_handler
     # After test
 
-    # Cleanup, stop and remove containers
-    current_path = os.getcwd()
-
-    for i in range(MAX_CONTAINERS):
-        try:
-            container_id = Containers.ID_PREFIX + str(i)
-            container_handler.stop_container(container_id)
-            container_handler.destroy_container(container_id)
-        except:
-            continue
-    # Remove folders for container storage
-    for i in range(MAX_CONTAINERS):
-        try:
-            container_handler.prune_volumes()
-        except:
-            continue
+    container_handler.shutdown()
 
 
-def test_create_one_container(config: dict):
-    container_handler = Containers()
+def test_create_one_container(config: dict, container_handler: Containers):
     container_handler.create_container(config)
     assert container_handler.status_container(config["ID"]) == Status.RUNNING
 
 
-def test_stop_container(config: dict):
-    container_handler = Containers()
+def test_stop_container(config: dict, container_handler: Containers):
     container_handler.create_container(config)
     container_handler.stop_container(config["ID"])
     assert container_handler.status_container(config["ID"]) == Status.EXITED
 
 
-def test_destroy_container(config: dict):
-    container_handler = Containers()
+def test_destroy_container(config: dict, container_handler: Containers):
     container_handler.create_container(config)
     container_handler.stop_container(config["ID"])
     container_handler.destroy_container(config["ID"])
     assert container_handler.status_container(config["ID"]) == Status.NOTFOUND
 
 
-def test_start_multiple_containers(config: dict):
-    container_handler = Containers()
-    container_id = 0
+def test_start_multiple_containers(config: dict, container_handler: Containers):
     user = "user"
     password = "password"
     for i in range(MAX_CONTAINERS):
-        config = container_handler.format_config(container_id, user, password)
-        container_id += 1
+        config = Containers.format_config(i, user, password)
         container_handler.create_container(config)
     for i in range(MAX_CONTAINERS):
         assert container_handler.status_container(Containers.ID_PREFIX + str(i)) == Status.RUNNING
 
 
-@pytest.mark.skip(reason="No way to test, random port assignment")
-def test_start_container_same_port(config: dict):
-    container_handler = Containers()
+def test_start_container_same_port(config: dict, container_handler: Containers):
+    user = "user"
+    password = "password"
+    with pytest.raises(Exception):
+        for i in range(2):
+            config = Containers.format_config(i, user, password, port=5555)
+            container_handler.create_container(config)
+
+
+def test_start_container_same_id(config: dict, container_handler: Containers):
     container_id = 0
     user = "user"
     password = "password"
     with pytest.raises(Exception):
         for i in range(MAX_CONTAINERS):
-            config = container_handler.format_config(container_id, user, password)
-            container_id += 1
+            config = Containers.format_config(container_id, user, password)
             container_handler.create_container(config)
 
 
-def test_start_container_same_id(config: dict):
-    container_handler = Containers()
-    container_id = 0
-    user = "user"
-    password = "password"
-    with pytest.raises(Exception):
-        for i in range(MAX_CONTAINERS):
-            config = container_handler.format_config(container_id, user, password)
-            container_handler.create_container(config)
-
-
-def test_destroy_twice(config: dict):
-    container_handler = Containers()
+def test_destroy_twice(config: dict, container_handler: Containers):
     with pytest.raises(Exception):
         container_handler.create_container(config)
         container_handler.stop_container(config["ID"])
@@ -111,31 +81,28 @@ def test_destroy_twice(config: dict):
 
 
 def test_format_config():
-    container_handler = Containers()
     container_id = 0
     user = "user"
     password = "password"
-    config = container_handler.format_config(container_id, user, password, {})
+    config = Containers.format_config(container_id, user, password, {})
     assert config["User"] == "user"
     assert config["Password"] == "password"
     assert config["ID"] == Containers.ID_PREFIX + str(container_id)
 
 
 def test_format_environment():
-    container_handler = Containers()
     uid = "1000"
     gid = "1001"
     timezone = "Europe/London"
     user = "user"
     password = "password"
     sudo_access = "true"
-    env = container_handler.format_environment(user, password, uid, gid, timezone, sudo_access)
+    env = Containers._format_environment(user, password, uid, gid, timezone, sudo_access)
     assert env == ['PUID='+uid, 'PGID='+gid, 'TZ='+timezone, 'SUDO_ACCESS='+sudo_access,
                    'PASSWORD_ACCESS=true', 'USER_PASSWORD='+password, 'USER_NAME='+user]
 
 
-def test_prune_volumes(config: dict):
-    container_handler = Containers()
+def test_prune_volumes(config: dict, container_handler: Containers):
     container_handler.create_container(config)
     container_handler.stop_container(config["ID"])
     container_handler.destroy_container(config["ID"])
@@ -144,14 +111,12 @@ def test_prune_volumes(config: dict):
         container_handler.get_volume(config["ID"])
 
 
-def test_get_volume(config: dict):
-    container_handler = Containers()
+def test_get_volume(config: dict, container_handler: Containers):
     container_handler.create_container(config)
     assert str(container_handler.get_volume(config["ID"] + "config")) == "<Volume: openssh-se>"
 
 
-@pytest.mark.skip(reason="No way to test at the moment, would have to know port")
-def test_get_port(config: dict):
-    container_handler = Containers()
+def test_get_port(config: dict, container_handler: Containers):
+    config['Port'] = {'2222/tcp': 2222}
     container_handler.create_container(config)
     assert container_handler.get_container_port(config["ID"]) == 2222

--- a/backend/tests/test_http_server.py
+++ b/backend/tests/test_http_server.py
@@ -9,12 +9,12 @@ import target_system_provider.target_system_provider_pb2 as messages
 
 
 @pytest.fixture(scope='module')
-def container_handler():
+def container_handler() -> Containers:
     return create_autospec(Containers)
 
 
 @pytest.fixture(scope='module', autouse=True)
-def http_server(container_handler: Containers):
+def http_server(container_handler: Containers) -> grpc.Server:
     http_server = server.start_http_server(
         container_handler,
         'PUBLIC_ADDRESS',
@@ -24,22 +24,26 @@ def http_server(container_handler: Containers):
 
 
 @pytest.fixture(scope='module')
-def grpc_channel():
+def grpc_channel() -> grpc.Channel:
     with grpc.insecure_channel('localhost:50051') as channel:
         yield channel
+
+
+@pytest.fixture(scope='module')
+def tsp_stub(grpc_channel: grpc.Channel):
+    return tsp.TargetSystemProviderStub(grpc_channel)
 
 
 @given(user=st.text(), password=st.text())
 def test_AcquireTargetSystem(
         container_handler: Containers,
-        grpc_channel: grpc.Channel,
+        tsp_stub: tsp.TargetSystemProviderStub,
         user: str, password: str):
     with patch.object(container_handler, 'format_config', return_value={'ID': 'openssh-server342'}):
         with patch.object(container_handler, 'create_container'):
             with patch.object(container_handler, 'get_container_port', return_value=53245):
 
-                stub = tsp.TargetSystemProviderStub(grpc_channel)
-                response = stub.AcquireTargetSystem(
+                response = tsp_stub.AcquireTargetSystem(
                     messages.AcquisitionRequest(
                         user=user,
                         password=password
@@ -56,16 +60,31 @@ def test_AcquireTargetSystem(
                 assert response.port == 53245
 
 
-@given(id=st.text())
+@given(user=st.text(), password=st.text())
 def test_YieldTargetSystem(
         container_handler: Containers,
-        grpc_channel: grpc.Channel,
-        id: str):
-    with patch.object(container_handler, 'stop_container'):
-        with patch.object(container_handler, 'destroy_container'):
-            stub = tsp.TargetSystemProviderStub(grpc_channel)
-            stub.YieldTargetSystem(
-                messages.YieldRequest(id=id))
+        tsp_stub: tsp.TargetSystemProviderStub,
+        user: str, password: str):
+    with patch.object(container_handler, 'format_config', return_value={'ID': 'openssh-server342'}):
+        with patch.object(container_handler, 'get_container_port', return_value=53245):
+            with patch.object(container_handler, 'stop_container'):
+                with patch.object(container_handler, 'destroy_container'):
+                    response = tsp_stub.AcquireTargetSystem(
+                        messages.AcquisitionRequest(
+                            user=user,
+                            password=password
+                        ))
 
-            container_handler.stop_container.assert_called_once_with(id)
-            container_handler.destroy_container.assert_called_once_with(id)
+                    tsp_stub.YieldTargetSystem(messages.YieldRequest(id=response.id))
+
+                    container_handler.stop_container.assert_called_once_with(response.id)
+                    container_handler.destroy_container.assert_called_once_with(response.id)
+
+
+@given(id=st.text())
+def test_YieldTargetSystem_non_existant_id_gives_not_found(
+        tsp_stub: tsp.TargetSystemProviderStub,
+        id: str):
+
+    with pytest.raises(grpc.RpcError):
+        tsp_stub.YieldTargetSystem(messages.YieldRequest(id=id))

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -63,6 +63,7 @@ services:
       dockerfile: backend/Dockerfile
     environment:
       TARGET_SYSTEM_ADDRESS: "host.docker.internal"
+      ENABLE_ISOLATED_TARGET_CONTAINER_NETWORKS: "False"
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
- Starts and stops tcpdump container along side target container
- Attaches to target container network to capture traffic for each session in isolation
- Stores captured network traffic as .pcap file in volume
- Additional option (`ENABLE_ISOLATED_TARGET_CONTAINER_NETWORKS`) to put each target container on its own network to make sure no broadcast traffic is redundantly captured. Also makes it so one target container cannot "see" other target containers.

How to test:
- Start like usual with `docker-compose up --build`
- Login to honeypot: `ssh localhost`
- Run a command which causes network traffic, e.g. `curl http://info.cern.ch/` (intentionally not HTTPS)
- Open `\\wsl$\docker-desktop-data\version-pack-data\community\docker\volumes\openssh-serverXXXX_netlog\log.pcap` in Wireshark and inspect network traffic

Known limitations:
- Encrypted network traffic cannot be decrypted since no encryption keys are currently collected.
- Network traffic is not sent to frontend and not saved to database.

Known issues:
- Option `ENABLE_ISOLATED_TARGET_CONTAINER_NETWORKS` is currently disabled by default since it does seems to start erroring after a while with many connections. The reason might be that Docker is running out of subnets, but I am not sure.