### PR TITLE
Frontend regex deny & % successrate

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       # Login success rate in percent (will bypass the above two settings)
       - SSH_LOGIN_SUCCESS_RATE
       # Regex that if matches will deny the login attempt
-      - SSH_REGEX_USERNAMES_DENY=.*[A-Z]
+      - SSH_REGEX_USERNAMES_DENY=[1-9]|.*[A-Z]
       - SSH_REGEX_PASSWORDS_DENY=^$$ # ($ escaped with $$)
       - SSH_SERVER_PORT=22
       - SSH_LOCAL_VERSION=SSH-2.0-dropbear_2019.78 # SSH version reported by the honeypot

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -31,15 +31,11 @@ services:
     ports:
       - "22:22"
     environment:
-      # Allowed usernames and passwords, multiple usernamse and passwords can be supplied
-      # by seperating them with ":". If they are left empty then everything is allowed
-      - SSH_ALLOWED_USERNAMES
-      - SSH_ALLOWED_PASSWORDS
-      # Login success rate in percent (will bypass the above two settings)
+      # Regexes for allowed login combinations
+      - SSH_ALLOWED_USERNAMES_REGEX=^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$$)$$ # ($ escaped with $$)
+      - SSH_ALLOWED_PASSWORDS_REGEX=^.{1,128}$$ # ($ escaped with $$)
+      # Login success rate in percent after the above regexes are checked
       - SSH_LOGIN_SUCCESS_RATE
-      # Regex that if matches will deny the login attempt
-      - SSH_REGEX_USERNAMES_DENY=[1-9]|.*[A-Z]
-      - SSH_REGEX_PASSWORDS_DENY=^$$ # ($ escaped with $$)
       - SSH_SERVER_PORT=22
       - SSH_LOCAL_VERSION=SSH-2.0-dropbear_2019.78 # SSH version reported by the honeypot
       - SSH_SESSION_TIMEOUT=600 # Timeout in seconds for when to treat an SSH connection inactive and end it

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -35,6 +35,11 @@ services:
       # by seperating them with ":". If they are left empty then everything is allowed
       - SSH_ALLOWED_USERNAMES
       - SSH_ALLOWED_PASSWORDS
+      # Login success rate in percent (will bypass the above two settings)
+      - SSH_LOGIN_SUCCESS_RATE
+      # Regex that if matches will deny the login attempt
+      - SSH_REGEX_USERNAMES_DENY=.*[A-Z]
+      - SSH_REGEX_PASSWORDS_DENY=^$$ # ($ escaped with $$)
       - SSH_SERVER_PORT=22
       - SSH_LOCAL_VERSION=SSH-2.0-dropbear_2019.78 # SSH version reported by the honeypot
       - SSH_SESSION_TIMEOUT=600 # Timeout in seconds for when to treat an SSH connection inactive and end it

--- a/frontend/docker-compose.yaml
+++ b/frontend/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       # Login success rate in percent (will bypass the above two settings)
       - SSH_LOGIN_SUCCESS_RATE
       # Regex that if matches will deny the login attempt 
-      - SSH_REGEX_USERNAMES_DENY=.*[A-Z]
+      - SSH_REGEX_USERNAMES_DENY=[1-9]|.*[A-Z]
       - SSH_REGEX_PASSWORDS_DENY=^$$ # ($ escaped with $$)
       - SSH_SERVER_PORT=22
       - SSH_LOCAL_VERSION=SSH-2.0-dropbear_2019.78 # SSH version reported by the honeypot

--- a/frontend/docker-compose.yaml
+++ b/frontend/docker-compose.yaml
@@ -7,15 +7,11 @@ services:
     ports:
       - "22:22"
     environment:
-      # Allowed usernames and passwords, multiple usernamse and passwords can be supplied
-      # by seperating them with ":". If they are left empty then everything is allowed
-      - SSH_ALLOWED_USERNAMES
-      - SSH_ALLOWED_PASSWORDS
-      # Login success rate in percent (will bypass the above two settings)
+      # Regexes for allowed login combinations
+      - SSH_ALLOWED_USERNAMES_REGEX=^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$$)$$ # ($ escaped with $$)
+      - SSH_ALLOWED_PASSWORDS_REGEX=^.{1,128}$$ # ($ escaped with $$)
+      # Login success rate in percent after the above regexes are checked
       - SSH_LOGIN_SUCCESS_RATE
-      # Regex that if matches will deny the login attempt 
-      - SSH_REGEX_USERNAMES_DENY=[1-9]|.*[A-Z]
-      - SSH_REGEX_PASSWORDS_DENY=^$$ # ($ escaped with $$)
       - SSH_SERVER_PORT=22
       - SSH_LOCAL_VERSION=SSH-2.0-dropbear_2019.78 # SSH version reported by the honeypot
       - SSH_SESSION_TIMEOUT=600 # Timeout in seconds for when to treat an SSH connection inactive and end it

--- a/frontend/docker-compose.yaml
+++ b/frontend/docker-compose.yaml
@@ -12,7 +12,10 @@ services:
       - SSH_ALLOWED_USERNAMES
       - SSH_ALLOWED_PASSWORDS
       # Login success rate in percent (will bypass the above two settings)
-      - SSH_LOGIN_SUCCESS_RATE=10
+      - SSH_LOGIN_SUCCESS_RATE
+      # Regex that if matches will deny the login attempt 
+      - SSH_REGEX_USERNAMES_DENY=.*[A-Z]
+      - SSH_REGEX_PASSWORDS_DENY=^$$ # ($ escaped with $$)
       - SSH_SERVER_PORT=22
       - SSH_LOCAL_VERSION=SSH-2.0-dropbear_2019.78 # SSH version reported by the honeypot
       - SSH_SESSION_TIMEOUT=600 # Timeout in seconds for when to treat an SSH connection inactive and end it

--- a/frontend/docker-compose.yaml
+++ b/frontend/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
       # by seperating them with ":". If they are left empty then everything is allowed
       - SSH_ALLOWED_USERNAMES
       - SSH_ALLOWED_PASSWORDS
+      # Login success rate in percent (will bypass the above two settings)
+      - SSH_LOGIN_SUCCESS_RATE=10
       - SSH_SERVER_PORT=22
       - SSH_LOCAL_VERSION=SSH-2.0-dropbear_2019.78 # SSH version reported by the honeypot
       - SSH_SESSION_TIMEOUT=600 # Timeout in seconds for when to treat an SSH connection inactive and end it

--- a/frontend/frontend/__main__.py
+++ b/frontend/frontend/__main__.py
@@ -69,8 +69,8 @@ def main() -> None:
                                   port=config.SSH_SERVER_PORT,
                                   socket_timeout=config.SSH_SOCKET_TIMEOUT,
                                   max_unaccepted_connetions=config.SSH_MAX_UNACCEPTED_CONNECTIONS,
-                                  usernames=config.SSH_ALLOWED_USERNAMES,
-                                  passwords=config.SSH_ALLOWED_PASSWORDS)
+                                  usernames=config.SSH_ALLOWED_USERNAMES_REGEX,
+                                  passwords=config.SSH_ALLOWED_PASSWORDS_REGEX)
     server.start()
     logger.info('SSH server started')
 

--- a/frontend/frontend/config/config.py
+++ b/frontend/frontend/config/config.py
@@ -5,28 +5,20 @@ import re
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
-# To provide multiple usernames or passwords, seperate them with a ":"
-# If theses are left empty, then every user and password combination is allowed
-SSH_ALLOWED_USERNAMES = None if os.getenv(
-    'SSH_ALLOWED_USERNAMES') is None else os.getenv('SSH_ALLOWED_USERNAMES').split(":")
-SSH_ALLOWED_PASSWORDS = None if os.getenv(
-    'SSH_ALLOWED_PASSWORDS') is None else os.getenv('SSH_ALLOWED_PASSWORDS').split(":")
+SSH_ALLOWED_USERNAMES_REGEX = os.getenv('SSH_ALLOWED_USERNAMES_REGEX')
+SSH_ALLOWED_PASSWORDS_REGEX = os.getenv('SSH_ALLOWED_PASSWORDS_REGEX')
+
+if SSH_ALLOWED_USERNAMES_REGEX is not None:
+    SSH_ALLOWED_USERNAMES_REGEX = re.compile(SSH_ALLOWED_USERNAMES_REGEX)
+
+if SSH_ALLOWED_PASSWORDS_REGEX is not None:
+    SSH_ALLOWED_PASSWORDS_REGEX = re.compile(SSH_ALLOWED_PASSWORDS_REGEX)
 
 # The port to lisen on
 SSH_SERVER_PORT = int(os.getenv('SSH_SERVER_PORT', '22'))
 
 # Success chance of login
 SSH_LOGIN_SUCCESS_RATE = int(os.getenv('SSH_LOGIN_SUCCESS_RATE', '-1'))
-
-# Regexes to deny usernamse or passwords
-SSH_REGEX_USERNAMES_DENY = os.getenv('SSH_REGEX_USERNAMES_DENY')
-SSH_REGEX_PASSWORDS_DENY = os.getenv('SSH_REGEX_PASSWORDS_DENY')
-
-if SSH_REGEX_USERNAMES_DENY is not None:
-    SSH_REGEX_USERNAMES_DENY = re.compile(SSH_REGEX_USERNAMES_DENY)
-
-if SSH_REGEX_PASSWORDS_DENY is not None:
-    SSH_REGEX_PASSWORDS_DENY = re.compile(SSH_REGEX_PASSWORDS_DENY)
 
 # The local version of the SSH server
 SSH_LOCAL_VERSION = os.getenv('SSH_LOCAL_VERSION', 'SSH-2.0-dropbear_2019.78')

--- a/frontend/frontend/config/config.py
+++ b/frontend/frontend/config/config.py
@@ -1,6 +1,7 @@
 """Module wrapping environment variables for configuration."""
 
 import os
+import re
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
@@ -16,6 +17,16 @@ SSH_SERVER_PORT = int(os.getenv('SSH_SERVER_PORT', '22'))
 
 # Success chance of login
 SSH_LOGIN_SUCCESS_RATE = int(os.getenv('SSH_LOGIN_SUCCESS_RATE', '-1'))
+
+# Regexes to deny usernamse or passwords
+SSH_REGEX_USERNAMES_DENY = os.getenv('SSH_REGEX_USERNAMES_DENY')
+SSH_REGEX_PASSWORDS_DENY = os.getenv('SSH_REGEX_PASSWORDS_DENY')
+
+if SSH_REGEX_USERNAMES_DENY is not None:
+    SSH_REGEX_USERNAMES_DENY = re.compile(SSH_REGEX_USERNAMES_DENY)
+
+if SSH_REGEX_PASSWORDS_DENY is not None:
+    SSH_REGEX_PASSWORDS_DENY = re.compile(SSH_REGEX_PASSWORDS_DENY)
 
 # The local version of the SSH server
 SSH_LOCAL_VERSION = os.getenv('SSH_LOCAL_VERSION', 'SSH-2.0-dropbear_2019.78')

--- a/frontend/frontend/config/config.py
+++ b/frontend/frontend/config/config.py
@@ -14,6 +14,9 @@ SSH_ALLOWED_PASSWORDS = None if os.getenv(
 # The port to lisen on
 SSH_SERVER_PORT = int(os.getenv('SSH_SERVER_PORT', '22'))
 
+# Success chance of login
+SSH_LOGIN_SUCCESS_RATE = int(os.getenv('SSH_LOGIN_SUCCESS_RATE', '-1'))
+
 # The local version of the SSH server
 SSH_LOCAL_VERSION = os.getenv('SSH_LOCAL_VERSION', 'SSH-2.0-dropbear_2019.78')
 

--- a/frontend/frontend/protocols/ssh/_ssh_server.py
+++ b/frontend/frontend/protocols/ssh/_ssh_server.py
@@ -1,8 +1,9 @@
-from ipaddress import AddressValueError,  ip_address
+from ipaddress import ip_address
 import logging
+from re import Pattern
 import random
 import datetime
-from typing import List, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from paramiko.common import (AUTH_FAILED, AUTH_SUCCESSFUL,
                              OPEN_FAILED_CONNECT_FAILED, OPEN_SUCCEEDED)
@@ -31,8 +32,8 @@ class Server(paramiko.ServerInterface):
             transport: paramiko.Transport,
             session: SSHSession,
             proxy_handler: ProxyHandler,
-            usernames: Optional[List[str]],
-            passwords: Optional[List[str]]) -> None:
+            usernames: Optional[Pattern],
+            passwords: Optional[Pattern]) -> None:
         super().__init__()
         self._transport = transport
         self._usernames = usernames
@@ -70,31 +71,19 @@ class Server(paramiko.ServerInterface):
         self._update_last_activity()
         self._session.log_login_attempt(username, password)
 
-        # Apply regex deny to username
-        if (config.SSH_REGEX_USERNAMES_DENY is not None
-                and config.SSH_REGEX_USERNAMES_DENY.match(username)):
+        # Verify the login attempt against our username and password regex
+        if self._usernames is not None and not self._usernames.match(username):
             return AUTH_FAILED
-
-        # Apply regex deny to password
-        if (config.SSH_REGEX_PASSWORDS_DENY is not None
-                and config.SSH_REGEX_PASSWORDS_DENY.match(password)):
+        if self._passwords is not None and not self._passwords.match(password):
             return AUTH_FAILED
 
         # Check if we have the LOGIN_SUCCESS_RATE set and apply it if we do
         if config.SSH_LOGIN_SUCCESS_RATE != -1:
-            if random.randint(1, 100) <= config.SSH_LOGIN_SUCCESS_RATE:
-                self._proxy_handler.set_attacker_credentials(username, password)
-                return AUTH_SUCCESSFUL
-            else:
+            if random.randint(1, 100) > config.SSH_LOGIN_SUCCESS_RATE:
                 return AUTH_FAILED
 
-        # Verify the login attempt against our own username and password list
-        if self._usernames is not None and not username in self._usernames:
-            return AUTH_FAILED
-        if self._passwords is None or password in self._passwords:
-            self._proxy_handler.set_attacker_credentials(username, password)
-            return AUTH_SUCCESSFUL
-        return AUTH_FAILED
+        self._proxy_handler.set_attacker_credentials(username, password)
+        return AUTH_SUCCESSFUL
 
     def check_auth_publickey(self, username: str, key: paramiko.PKey) -> int:
         self._update_last_activity()

--- a/frontend/frontend/protocols/ssh/_ssh_server.py
+++ b/frontend/frontend/protocols/ssh/_ssh_server.py
@@ -70,6 +70,16 @@ class Server(paramiko.ServerInterface):
         self._update_last_activity()
         self._session.log_login_attempt(username, password)
 
+        # Apply regex deny to username
+        if (config.SSH_REGEX_USERNAMES_DENY is not None
+                and config.SSH_REGEX_USERNAMES_DENY.match(username)):
+            return AUTH_FAILED
+
+        # Apply regex deny to password
+        if (config.SSH_REGEX_PASSWORDS_DENY is not None
+                and config.SSH_REGEX_PASSWORDS_DENY.match(password)):
+            return AUTH_FAILED
+
         # Check if we have the LOGIN_SUCCESS_RATE set and apply it if we do
         if config.SSH_LOGIN_SUCCESS_RATE != -1:
             if random.randint(1, 100) <= config.SSH_LOGIN_SUCCESS_RATE:

--- a/frontend/frontend/protocols/ssh/_ssh_server.py
+++ b/frontend/frontend/protocols/ssh/_ssh_server.py
@@ -83,6 +83,7 @@ class Server(paramiko.ServerInterface):
         # Check if we have the LOGIN_SUCCESS_RATE set and apply it if we do
         if config.SSH_LOGIN_SUCCESS_RATE != -1:
             if random.randint(1, 100) <= config.SSH_LOGIN_SUCCESS_RATE:
+                self._proxy_handler.set_attacker_credentials(username, password)
                 return AUTH_SUCCESSFUL
             else:
                 return AUTH_FAILED

--- a/frontend/frontend/protocols/ssh/connection_manager.py
+++ b/frontend/frontend/protocols/ssh/connection_manager.py
@@ -3,8 +3,9 @@ import logging
 import socket
 import threading
 import urllib.request
+from re import Pattern
 from ipaddress import ip_address
-from typing import List, Optional
+from typing import Optional
 
 
 import paramiko
@@ -30,8 +31,8 @@ class ConnectionManager(threading.Thread):
     def __init__(self,
                  target_system_provider: TargetSystemProvider,
                  host_key: paramiko.PKey,
-                 usernames: Optional[List[str]] = None,
-                 passwords: Optional[List[str]] = None,
+                 usernames: Optional[Pattern] = None,
+                 passwords: Optional[Pattern] = None,
                  socket_timeout: float = 5,
                  max_unaccepted_connetions: int = 100,
                  port: int = 22) -> None:

--- a/frontend/tests/protocols/ssh/test_connection_manager.py
+++ b/frontend/tests/protocols/ssh/test_connection_manager.py
@@ -1,5 +1,6 @@
 import socket
 import time
+import re
 from unittest.mock import MagicMock, PropertyMock, patch, create_autospec
 
 import pytest
@@ -16,8 +17,8 @@ def connection_manager() -> ConnectionManager:
     return ConnectionManager(
         create_autospec(TargetSystemProvider),
         key,
-        [""],
-        [""],
+        re.compile(""),
+        re.compile(""),
         port=2222,
         socket_timeout=0.2)
 

--- a/frontend/tests/protocols/ssh/test_ssh_server.py
+++ b/frontend/tests/protocols/ssh/test_ssh_server.py
@@ -44,7 +44,7 @@ def proxy_handler(logger, target_system_provider) -> ProxyHandler:
 def ssh_server(logger, proxy_handler) -> Server:
     transport_mock = MagicMock()
     transport_mock.remote_version = "ExampleVersion"
-    return Server(transport_mock, logger, proxy_handler, [""], [""])
+    return Server(transport_mock, logger, proxy_handler, re.compile(""), re.compile(""))
 
 
 def test_update_last_activity_without_started_session(ssh_server: Server, logger: SSHSession):

--- a/frontend/tests/protocols/ssh/test_ssh_server.py
+++ b/frontend/tests/protocols/ssh/test_ssh_server.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 import logging
 import pytest
 from ipaddress import ip_address
@@ -79,8 +80,8 @@ def test_get_last_activity(ssh_server: Server):
 
 
 def test_check_username_password(ssh_server: Server):
-    ssh_server._usernames = ["linus"]
-    ssh_server._passwords = ["torvalds"]
+    ssh_server._usernames = re.compile(r"linus")
+    ssh_server._passwords = re.compile(r"torvalds")
     now = datetime.datetime.now()
 
     assert ssh_server.check_auth_password("linus", "torvalds") == AUTH_SUCCESSFUL


### PR DESCRIPTION
- Adds the ability to match regex on usernames and password and deny the login attempt
- Adds the ability to provide a percentage chance of a successful login

To test: either mess with the REGEX environment variables or the SSH_LOGIN_SUCCESS_RATE variable. The default username regex should only allow usernames allowed by unix, while the default password regex just accepts any string that is of length 1 to 128.