### PR TITLE
Ease of use docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 ## Running the honeypot on one machine
 
 ### Configuration
-Change the values in `/dev/docker-compose.yaml`, at minimum it is recommended to change the username and password for the database. 
+Change the values in `/dev/docker-compose.yaml`, at minimum it is recommended to change the username and password for the database.
+Note that if the entire honeypot will be running on a Linux host, the value for `TARGET_SYSTEM_ADDRESS` must be set to `"172.17.0.1"`.
 
 ### Running
 Run the docker-compose.yaml in the `/dev` directory file using `docker-compose up -d` to start all modules of the honeypot together.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 * Port 5432 is used for the database by default, needs to be open for the database machine.
 * Port 22 is used on system(s) that runs the frontend(s), if the system provides an SSH-server it needs to be changed to another port or disabled. This port needs to be open for the frontend machine(s).
 * Ports 49152-65535 (IANA unregistered ports) are used for communication between the frontend and backend, so these need to be open for the backend machine.
+* Port 80 is used for the backend HTTP API, and needs to be open for the backend.
 
 ## Running the honeypot on one machine
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Botnet Honeypot
 
 ## Requirements
+
+### System and software
+Recommended minimum amount of RAM is 1GB.
+The machine running the backend is recommended to have a multi-core CPU.
+An operating system capable of running Docker, see [Supported Platforms](https://docs.docker.com/engine/install/#supported-platforms), note that this software has not been tested on the Mac operating system.
+Docker is required to be installed, see [Installing Docker](https://docs.docker.com/engine/install/)
+
+### Network
 * Port 5432 is used for the database by default, needs to be open for the database machine.
 * Port 22 is used on system(s) that runs the frontend(s), if the system provides an SSH-server it needs to be changed to another port or disabled. This port needs to be open for the frontend machine(s).
 * Ports 49152-65535 (IANA unregistered ports) are used for communication between the frontend and backend, so these need to be open for the backend machine.

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Change the TARGET_SYSTEM_ADDRESS in `/backend/docker-compose.yaml` to the IP of 
 ### Running
 
 #### On the host which will be running the database
-Run the docker-compose.yaml in the `/database` directory file using `docker-compose up -d` to start all modules of the honeypot together.
+Run the docker-compose.yaml in the `/database` directory file using `docker-compose up -d` to start the database.
 
 #### On the host which will be running the frontend
-Run the docker-compose.yaml in the `/frontend` directory file using `docker-compose up -d` to start all modules of the honeypot together.
+Run the docker-compose.yaml in the `/frontend` directory file using `docker-compose up -d` to start the frontend.
 
 #### On the host which will be running the backend
-Run the docker-compose.yaml in the `/backend` directory file using `docker-compose up -d` to start all modules of the honeypot together.
+Run the docker-compose.yaml in the `/backend` directory file using `docker-compose up -d` to start the backend.
 
 ##### (optional) Trying to prevent DDoS and other attacks
 Since this project implements a high interaction honeypot, the attackers gain access to the resources available to the backend host. 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Since this project implements a high interaction honeypot, the attackers gain ac
 Therefore, we provide a WIP script for limiting the bandwidth on the backend. The script is provided as-is and worked on Ubuntu Linux 18.04.
 The script limits most outgoing traffic from the backend host to 10 Mbit/s, and traffic on ports 21, 22, 23, 25, 53, 110, 135, 137, 138, 139, 1433, and 1434 to 1kbit/s. The speeds are configurable in the script using variables.
 It does not limit incoming traffic speed. It has not been tested while running the entire honeypot on a single host.
-The script is placed in 
+The script is provided in `/backend/traffic_limit.sh`.
 
 ## Accessing the collected information
 Connect, using your preferred utility, to the IP address of the database providing the user name, password and database name you configured previously.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,59 @@
 # Botnet Honeypot
 
+## Requirements
+* Port 5432 is used for the database by default, needs to be open for the database machine.
+* Port 22 is used on system(s) that runs the frontend(s), if the system provides an SSH-server it needs to be changed to another port or disabled. This port needs to be open for the frontend machine(s).
+* Ports 49152-65535 (IANA unregistered ports) are used for communication between the frontend and backend, so these need to be open for the backend machine.
+
+## Running the honeypot on one machine
+
+### Configuration
+Change the values in `/dev/docker-compose.yaml`, at minimum it is recommended to change the username and password for the database. 
+
+### Running
+Run the docker-compose.yaml in the `/dev` directory file using `docker-compose up -d` to start all modules of the honeypot together.
+
+## Running each module on separate machines
+
+### Configuration
+
+#### On the host which will be running the database
+Change the values in `/database/docker-compose.yaml`, at minimum it is recommended to change the username and password for the database. 
+
+#### On the host which will be running the frontend
+Change the values in `/frontend/docker-compose.yaml` to fit your needs. At the minimum, the database connection settings and backend address must be filled in:
+* DB_HOSTNAME: IP address to the database host machine
+* DB_DATABASE: Database that will be accessed in the database.
+* DB_USERNAME: Database user name.
+* DB_PASSWORD: Database password.
+* BACKEND_ADDRESS: IP address to the backend host machine.
+
+#### On the host which will be running the backend
+Change the TARGET_SYSTEM_ADDRESS in `/backend/docker-compose.yaml` to the IP of the host machine that will be running the backend.
+
+### Running
+
+#### On the host which will be running the database
+Run the docker-compose.yaml in the `/database` directory file using `docker-compose up -d` to start all modules of the honeypot together.
+
+#### On the host which will be running the frontend
+Run the docker-compose.yaml in the `/frontend` directory file using `docker-compose up -d` to start all modules of the honeypot together.
+
+#### On the host which will be running the backend
+Run the docker-compose.yaml in the `/backend` directory file using `docker-compose up -d` to start all modules of the honeypot together.
+
+##### (optional) Trying to prevent DDoS and other attacks
+Since this project implements a high interaction honeypot, the attackers gain access to the resources available to the backend host. 
+Therefore, we provide a WIP script for limiting the bandwidth on the backend. The script is provided as-is and worked on Ubuntu Linux 18.04.
+The script limits most outgoing traffic from the backend host to 10 Mbit/s, and traffic on ports 21, 22, 23, 25, 53, 110, 135, 137, 138, 139, 1433, and 1434 to 1kbit/s. The speeds are configurable in the script using variables.
+It does not limit incoming traffic speed. It has not been tested while running the entire honeypot on a single host.
+The script is placed in 
+
+## Accessing the collected information
+Connect, using your preferred utility, to the IP address of the database providing the user name, password and database name you configured previously.
+
+For example, using psql: `psql <db_name> -h <ip_address> -U <db_user>` and then provide the password when prompted.
+
 ## Development
 
 - [Python Setup](documentation/python_setup.md)

--- a/backend/traffic_limit.sh
+++ b/backend/traffic_limit.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# script for limiting the bandwidth on all ports except the IANA unregistered port range
+# adapted from https://unix.stackexchange.com/questions/76495/which-set-of-commands-will-limit-the-outgoing-data-rate-to-x-kbps-for-traffic-to
+
+# network interface on which to limit traffic
+IF="eth0"
+# limit of the network interface in question
+LINKCEIL="1gbit"
+# rate of default limit
+LIMIT1="10mbit"
+# rate of super-limit
+LIMIT2="1kbit"
+
+# delete existing rules
+tc qdisc del dev ${IF} root
+
+# add root class, 1:11 default for all unspecified traffic
+tc qdisc add dev ${IF} root handle 1: htb default 11
+
+# add parent class
+tc class add dev ${IF} parent 1: classid 1:1 htb rate ${LINKCEIL} ceil ${LINKCEIL}
+
+# add our classes.
+# 1:10 unlimited bandwidth
+# 1:11 limited to LIMIT1 bandwidth, default for all unspecified traffic
+# 1:12 super-limited to LIMIT2 bandwidth
+tc class add dev ${IF} parent 1:1 classid 1:10 htb rate ${LINKCEIL} ceil ${LINKCEIL} prio 0
+tc class add dev ${IF} parent 1:1 classid 1:11 htb rate ${LIMIT1} ceil ${LIMIT1} prio 1
+tc class add dev ${IF} parent 1:1 classid 1:12 htb rate ${LIMIT2} ceil ${LIMIT2} prio 2
+
+# add handles to our classes so packets marked with <x> go into the class with "... handle <x> fw ..."
+tc filter add dev ${IF} parent 1: protocol ip prio 1 handle 1 fw classid 1:10
+tc filter add dev ${IF} parent 1: protocol ip prio 2 handle 2 fw classid 1:11
+tc filter add dev ${IF} parent 1: protocol ip prio 3 handle 3 fw classid 1:12
+
+# sends packets in port range 49152:65535 to 1:10 (unlimited)
+# sends packets in port list  21,22,23,25,53,110,135,137,138,139,1433,1434 to 1:12 (super-limited by LIMIT2)
+# sends all other packets to 1:11 (limited by LIMIT1)
+iptables -t mangle -A OUTPUT -p tcp --match multiport --sport 49152:65535 -j MARK --set-mark 0x1
+iptables -t mangle -A OUTPUT -p tcp --match multiport --dport 49152:65535 -j MARK --set-mark 0x1
+iptables -t mangle -A OUTPUT -p tcp --match multiport --sports 21,22,23,25,53,110,135,137,138,139,1433,1434 -j MARK --set-mark 0x3
+iptables -t mangle -A OUTPUT -p tcp --match multiport --dports 21,22,23,25,53,110,135,137,138,139,1433,1434 -j MARK --set-mark 0x3
+iptables -t mangle -A OUTPUT -p tcp -j MARK --set-mark 0x2


### PR DESCRIPTION
Documentation for configuring and starting our project.
Required for the section in the report for "Ease of Use", and also good to have for anyone not familiar who would like to try the software.

Includes (somewhat experimental) script for the backend which limits the bandwidth in order to try to avoid having the honeypot be usable in any attacks (DDoS or other).